### PR TITLE
2.2.3

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -1,320 +1,382 @@
 jQuery(document).ready(function ($) {
 
+	var performingAjax = false;
+
+	var blockCartWidget = function blockCartWidget() {
+		$('#klarna-checkout-widget').fadeTo( '400', '0.6' ).block({
+			message: null,
+			overlayCSS: {
+				background: '#fff',
+				opacity: 0.6
+			}
+		});
+	}
+
+	var unblockCartWidget = function unblockCartWidget() {
+		$('#klarna-checkout-widget').css( 'opacity', '1' ).unblock();
+	}
+
 	// Update country
 	$(document).on('change', 'select#klarna-checkout-euro-country', function (event) {
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		new_country = $(this).val();
-
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_country_callback',
-					new_country: new_country,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					document.location.assign(response.data.new_url);
-				},
-				error: function (response) {
-					console.log('select euro country AJAX error');
-					console.log(response);
-				}
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
 			}
-		);
 
+			new_country = $(this).val();
+
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_country_callback',
+						new_country: new_country,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						document.location.assign(response.data.new_url);
+					},
+					error: function (response) {
+						console.log('select euro country AJAX error');
+						console.log(response);
+					},
+					complete: function () {
+						performingAjax = false;
+						unblockCartWidget();
+					}
+				}
+			);
+		}
 	});
 
 	// Update order note
 	$(document).on('change', 'textarea#klarna-checkout-order-note, #kco_order_note', function (event) {
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		order_note = $(this).val();
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
+			}
 
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_order_note_callback',
-					order_note: order_note,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-				},
-				error: function (response) {
-					console.log('order note AJAX error');
-					console.log(response);
-				},
-				complete: function() {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
+			order_note = $(this).val();
+
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_order_note_callback',
+						order_note: order_note,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+					},
+					error: function (response) {
+						console.log('order note AJAX error');
+						console.log(response);
+					},
+					complete: function () {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						performingAjax = false;
+						unblockCartWidget();
 					}
 				}
-			}
-		);
-
+			);
+		}
 	});
 
 	// Update shipping (v2)
 	$(document).on('change', 'table#kco-totals #kco-page-shipping input[type="radio"]', function (event) {
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		new_method = $(this).val();
-		kco_widget = $('#klarna-checkout-widget');
-
-		$(document.body).trigger('kco_widget_update_shipping', new_method);
-
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_shipping_callback',
-					new_method: new_method,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					$(kco_widget).html(response.data.widget_html);
-				},
-				error: function (response) {
-					console.log('update shipping AJAX error');
-					console.log(response);
-				},
-				complete: function() {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
-					}
-
-					$(document.body).trigger('kco_widget_updated_shipping', new_method);
-				}
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
 			}
-		);
 
+			new_method = $(this).val();
+			kco_widget = $('#klarna-checkout-widget');
+
+			$(document.body).trigger('kco_widget_update_shipping', new_method);
+
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_shipping_callback',
+						new_method: new_method,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						$(kco_widget).html(response.data.widget_html);
+					},
+					error: function (response) {
+						console.log('update shipping AJAX error');
+						console.log(response);
+					},
+					complete: function () {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						$(document.body).trigger('kco_widget_updated_shipping', new_method);
+						performingAjax = false;
+						unblockCartWidget();
+					}
+				}
+			);
+		}
 	});
 
 	// Update cart (v2)
 	$(document).on('change', 'td.product-quantity input[type=number]', function (event) {
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		ancestor = $(this).closest('td.product-quantity');
-		cart_item_key = $(ancestor).data('cart_item_key');
-		new_quantity = $(this).val();
-		kco_widget = $('#klarna-checkout-widget');
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
+			}
 
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_cart_callback_update',
-					cart_item_key: cart_item_key,
-					new_quantity: new_quantity,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					$(kco_widget).html(response.data.widget_html);
-				},
-				error: function (response) {
-					console.log('update cart item AJAX error');
-					console.log(response);
-				},
-				complete: function() {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
+			ancestor = $(this).closest('td.product-quantity');
+			cart_item_key = $(ancestor).data('cart_item_key');
+			new_quantity = $(this).val();
+			kco_widget = $('#klarna-checkout-widget');
+
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_cart_callback_update',
+						cart_item_key: cart_item_key,
+						new_quantity: new_quantity,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						$(kco_widget).html(response.data.widget_html);
+					},
+					error: function (response) {
+						console.log('update cart item AJAX error');
+						console.log(response);
+					},
+					complete: function () {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						performingAjax = false;
+						unblockCartWidget();
 					}
 				}
-			}
-		);
+			);
+		}
 	});
 
 	// Remove cart item (v2)
 	$(document).on('click', 'td.kco-product-remove a', function (event) {
-		event.preventDefault();
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+			event.preventDefault();
 
-		ancestor = $(this).closest('tr').find('td.product-quantity');
-		item_row = $(this).closest('tr');
-		kco_widget = $('#klarna-checkout-widget');
-		cart_item_key_remove = $(ancestor).data('cart_item_key');
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
+			}
 
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_cart_callback_remove',
-					cart_item_key_remove: cart_item_key_remove,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					if (0 == response.data.item_count) {
-						location.reload();
-					} else {
-						$(kco_widget).html(response.data.widget_html);
-						$(item_row).remove();
+			ancestor = $(this).closest('tr').find('td.product-quantity');
+			item_row = $(this).closest('tr');
+			kco_widget = $('#klarna-checkout-widget');
+			cart_item_key_remove = $(ancestor).data('cart_item_key');
 
-						if (typeof window._klarnaCheckout != 'function') {
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_cart_callback_remove',
+						cart_item_key_remove: cart_item_key_remove,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						if (0 == response.data.item_count) {
 							location.reload();
+						} else {
+							$(kco_widget).html(response.data.widget_html);
+							$(item_row).remove();
+
+							if (typeof window._klarnaCheckout != 'function') {
+								location.reload();
+							}
 						}
-					}
-				},
-				error: function (response) {
-					console.log('remove cart item AJAX error');
-					console.log(response);
-				},
-				complete: function (response) {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
+					},
+					error: function (response) {
+						console.log('remove cart item AJAX error');
+						console.log(response);
+					},
+					complete: function (response) {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						performingAjax = false;
+						unblockCartWidget();
 					}
 				}
-			}
-		);
+			);
+		}
 	});
 
 	// Add coupon (v2)
 	$('#klarna-checkout-widget .checkout_coupon').off(); // Remove WC built-in event handler
 	$(document).on('submit', '#klarna-checkout-widget .checkout_coupon', function (event) {
-		event.preventDefault();
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		$('#klarna_checkout_coupon_result').html('');
+			event.preventDefault();
 
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+			$('#klarna_checkout_coupon_result').html('');
 
-		coupon = $('#klarna-checkout-widget #coupon_code').val();
-		kco_widget = $('#klarna-checkout-widget');
-		input_field = $(this).find('#coupon_code');
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
+			}
 
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_coupons_callback',
-					coupon: coupon,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					if (response.data.coupon_success) {
-						$('#klarna_checkout_coupon_result').html('<p>' + kcoAjax.coupon_success + '</p>');
+			coupon = $('#klarna-checkout-widget #coupon_code').val();
+			kco_widget = $('#klarna-checkout-widget');
+			input_field = $(this).find('#coupon_code');
 
-						html_string = '<tr class="kco-applied-coupon"><td class="kco-rightalign">Coupon: ' + response.data.coupon + ' <a class="kco-remove-coupon" data-coupon="' + response.data.coupon + '" href="#">(remove)</a></td><td class="kco-rightalign">-' + response.data.amount + '</td></tr>';
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_coupons_callback',
+						coupon: coupon,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						if (response.data.coupon_success) {
+							$('#klarna_checkout_coupon_result').html('<p>' + kcoAjax.coupon_success + '</p>');
 
-						$('tr#kco-page-total').before(html_string);
-						$(input_field).val('');
-						$(kco_widget).html(response.data.widget_html);
+							html_string = '<tr class="kco-applied-coupon"><td class="kco-rightalign">Coupon: ' + response.data.coupon + ' <a class="kco-remove-coupon" data-coupon="' + response.data.coupon + '" href="#">(remove)</a></td><td class="kco-rightalign">-' + response.data.amount + '</td></tr>';
 
-						if (typeof window._klarnaCheckout != 'function') {
-							location.reload();
+							$('tr#kco-page-total').before(html_string);
+							$(input_field).val('');
+							$(kco_widget).html(response.data.widget_html);
+
+							if (typeof window._klarnaCheckout != 'function') {
+								location.reload();
+							}
 						}
-					}
-					else {
+						else {
+							$('#klarna_checkout_coupon_result').html('<div class="woocommerce-error">' + kcoAjax.coupon_fail + '</div>');
+						}
+					},
+					error: function (response) {
 						$('#klarna_checkout_coupon_result').html('<div class="woocommerce-error">' + kcoAjax.coupon_fail + '</div>');
-					}
-				},
-				error: function (response) {
-					$('#klarna_checkout_coupon_result').html('<div class="woocommerce-error">' + kcoAjax.coupon_fail + '</div>');
-					console.log('add coupon AJAX error');
-					console.log(response);
-				},
-				complete: function (response) {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
+						console.log('add coupon AJAX error');
+						console.log(response);
+					},
+					complete: function (response) {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						performingAjax = false;
+						unblockCartWidget();
 					}
 				}
-			}
-		);
-
+			);
+		}
 	});
 
 
 	// Remove coupon (v2)
 	$(document).on('click', 'table#kco-totals .kco-remove-coupon', function (event) {
-		event.preventDefault();
+		if (!performingAjax) {
+			performingAjax = true;
+			blockCartWidget();
 
-		if (typeof window._klarnaCheckout == 'function') {
-			window._klarnaCheckout(function (api) {
-				api.suspend();
-			});
-		}
+			event.preventDefault();
 
-		remove_coupon = $(this).data('coupon');
-		clicked_el = $(this);
-		kco_widget = $('#klarna-checkout-widget');
+			if (typeof window._klarnaCheckout == 'function') {
+				window._klarnaCheckout(function (api) {
+					api.suspend();
+				});
+			}
 
-		$.ajax(
-			kcoAjax.ajaxurl,
-			{
-				type: 'POST',
-				dataType: 'json',
-				data: {
-					action: 'klarna_checkout_remove_coupon_callback',
-					remove_coupon: remove_coupon,
-					nonce: kcoAjax.klarna_checkout_nonce
-				},
-				success: function (response) {
-					$(clicked_el).closest('tr').remove();
-					$(kco_widget).html(response.data.widget_html);
+			remove_coupon = $(this).data('coupon');
+			clicked_el = $(this);
+			kco_widget = $('#klarna-checkout-widget');
 
-					// Remove WooCommerce notification
-					$('#klarna-checkout-widget .woocommerce-info + .woocommerce-message').remove();
-				},
-				error: function (response) {
-					console.log('remove coupon AJAX error');
-					console.log(response);
-				},
-				complete: function (response) {
-					if (typeof window._klarnaCheckout == 'function') {
-						window._klarnaCheckout(function (api) {
-							api.resume();
-						});
+			$.ajax(
+				kcoAjax.ajaxurl,
+				{
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						action: 'klarna_checkout_remove_coupon_callback',
+						remove_coupon: remove_coupon,
+						nonce: kcoAjax.klarna_checkout_nonce
+					},
+					success: function (response) {
+						$(clicked_el).closest('tr').remove();
+						$(kco_widget).html(response.data.widget_html);
+
+						// Remove WooCommerce notification
+						$('#klarna-checkout-widget .woocommerce-info + .woocommerce-message').remove();
+					},
+					error: function (response) {
+						console.log('remove coupon AJAX error');
+						console.log(response);
+					},
+					complete: function (response) {
+						if (typeof window._klarnaCheckout == 'function') {
+							window._klarnaCheckout(function (api) {
+								api.resume();
+							});
+						}
+						performingAjax = false;
+						unblockCartWidget();
 					}
 				}
-			}
-		);
+			);
+		}
 	});
 
 	// End KCO widget

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2016.10.xx  - version 2.2.3
 * Fix       - Fixes the error in settings page when using Klarna and MasterPass plugins together.
+* Update    - Disables Klarna Checkout autofocus on mobile.
 
 2016.10.19  - version 2.2.2
 * Fix       - Adds back shipping cost calculation based on shipping postal code returned from Klarna in KCO.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2016.10.xx  - version 2.2.3
+2016.11.14  - version 2.2.3
 * Fix       - Fixes the error in settings page when using Klarna and MasterPass plugins together.
 * Update    - Disables Klarna Checkout autofocus on mobile.
 * Fix       - Adds Klarna Checkout setting that allows is_order_received_page() to return true on KCO thank you page.
 * Fix       - Adds JS fix for duplicate order items in KCO.
+* Update    - Adds only_shipping="yes" attribute to woocommerce_klarna_checkout_widget shortcode allowing it to only show shipping.
 
 2016.10.19  - version 2.2.2
 * Fix       - Adds back shipping cost calculation based on shipping postal code returned from Klarna in KCO.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2016.10.xx  - version 2.2.3
+* Fix       - Fixes the error in settings page when using Klarna and MasterPass plugins together.
+
 2016.10.19  - version 2.2.2
 * Fix       - Adds back shipping cost calculation based on shipping postal code returned from Klarna in KCO.
 * Fix       - Fixes empty incompatibility with PHP 5.4.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2016.10.xx  - version 2.2.3
 * Fix       - Fixes the error in settings page when using Klarna and MasterPass plugins together.
 * Update    - Disables Klarna Checkout autofocus on mobile.
+* Fix       - Adds Klarna Checkout setting that allows is_order_received_page() to return true on KCO thank you page.
 
 2016.10.19  - version 2.2.2
 * Fix       - Adds back shipping cost calculation based on shipping postal code returned from Klarna in KCO.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix       - Fixes the error in settings page when using Klarna and MasterPass plugins together.
 * Update    - Disables Klarna Checkout autofocus on mobile.
 * Fix       - Adds Klarna Checkout setting that allows is_order_received_page() to return true on KCO thank you page.
+* Fix       - Adds JS fix for duplicate order items in KCO.
 
 2016.10.19  - version 2.2.2
 * Fix       - Adds back shipping cost calculation based on shipping postal code returned from Klarna in KCO.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1969,23 +1969,25 @@ class WC_Gateway_Klarna_Checkout_Extra {
 	 *
 	 **/
 	function change_checkout_url( $url ) {
-		global $woocommerce;
-		global $klarna_checkout_url;
-		$checkout_settings            = get_option( 'woocommerce_klarna_checkout_settings' );
-		$enabled                      = $checkout_settings['enabled'];
-		$modify_standard_checkout_url = $checkout_settings['modify_standard_checkout_url'];
-		$klarna_country               = WC()->session->get( 'klarna_country' );
-		$available_countries          = $this->get_authorized_countries();
-		// Change the Checkout URL if this is enabled in the settings
-		if ( $modify_standard_checkout_url == 'yes' && $enabled == 'yes' && ! empty( $klarna_checkout_url ) && in_array( strtoupper( $klarna_country ), $available_countries ) && array_key_exists( strtoupper( $klarna_country ), WC()->countries->get_allowed_countries() ) ) {
-			if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
-				if ( in_array( strtoupper( $klarna_country ), array( 'SE', 'FI', 'NO' ) ) ) {
-					$url = $klarna_checkout_url;
+		if ( ! is_admin() ) {
+			global $woocommerce;
+			global $klarna_checkout_url;
+			$checkout_settings            = get_option( 'woocommerce_klarna_checkout_settings' );
+			$enabled                      = $checkout_settings['enabled'];
+			$modify_standard_checkout_url = $checkout_settings['modify_standard_checkout_url'];
+			$klarna_country               = WC()->session->get( 'klarna_country' );
+			$available_countries          = $this->get_authorized_countries();
+			// Change the Checkout URL if this is enabled in the settings
+			if ( $modify_standard_checkout_url == 'yes' && $enabled == 'yes' && ! empty( $klarna_checkout_url ) && in_array( strtoupper( $klarna_country ), $available_countries ) && array_key_exists( strtoupper( $klarna_country ), WC()->countries->get_allowed_countries() ) ) {
+				if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+					if ( in_array( strtoupper( $klarna_country ), array( 'SE', 'FI', 'NO' ) ) ) {
+						$url = $klarna_checkout_url;
+					} else {
+						return $url;
+					}
 				} else {
-					return $url;
+					$url = $klarna_checkout_url;
 				}
-			} else {
-				$url = $klarna_checkout_url;
 			}
 		}
 

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -2105,7 +2105,7 @@ class WC_Gateway_Klarna_Checkout_Extra {
 					}
 					if ( strpos( $cs_key, 'klarna_checkout_thanks_url_' ) !== false && '' != $cs_value ) {
 						$clean_thank_you_uri = explode( '?', $cs_value );
-						$clean_thank_you_uri = $clean_checkout_uri[0];
+						$clean_thank_you_uri = $clean_thank_you_uri[0];
 						$thank_you_pages[ $cs_key ] = substr( $clean_thank_you_uri, 0 - $length );
 					}
 				}

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -2098,11 +2098,15 @@ class WC_Gateway_Klarna_Checkout_Extra {
 			// Get arrays of checkout and thank you pages for all countries
 			if ( is_array( $checkout_settings ) ) {
 				foreach ( $checkout_settings as $cs_key => $cs_value ) {
-					if ( strpos( $cs_key, 'klarna_checkout_url_' ) !== false ) {
-						$checkout_pages[ $cs_key ] = substr( $cs_value, 0 - $length );
+					if ( strpos( $cs_key, 'klarna_checkout_url_' ) !== false && '' != $cs_value ) {
+						$clean_checkout_uri = explode( '?', $cs_value );
+						$clean_checkout_uri = $clean_checkout_uri[0];
+						$checkout_pages[ $cs_key ] = substr( $clean_checkout_uri, 0 - $length );
 					}
-					if ( strpos( $cs_key, 'klarna_checkout_thanks_url_' ) !== false ) {
-						$thank_you_pages[ $cs_key ] = substr( $cs_value, 0 - $length );
+					if ( strpos( $cs_key, 'klarna_checkout_thanks_url_' ) !== false && '' != $cs_value ) {
+						$clean_thank_you_uri = explode( '?', $cs_value );
+						$clean_thank_you_uri = $clean_checkout_uri[0];
+						$thank_you_pages[ $cs_key ] = substr( $clean_thank_you_uri, 0 - $length );
 					}
 				}
 			}

--- a/includes/checkout/create.php
+++ b/includes/checkout/create.php
@@ -146,6 +146,9 @@ if ( $this->testmode !== 'yes' ) {
 }
 
 $create['gui']['layout'] = $klarna_checkout_layout;
+if ( wp_is_mobile() ) {
+	$create['gui']['options'] = array( 'disable_autofocus' );
+}
 
 $klarna_order_total = 0;
 $klarna_tax_total   = 0;

--- a/includes/settings-checkout.php
+++ b/includes/settings-checkout.php
@@ -453,6 +453,12 @@ return apply_filters( 'klarna_checkout_form_fields', array(
 		'label'       => sprintf( __( 'If this option is checked cross-sell product will be shown in Klarna Checkout thank you page, allowing customers to add them to the order they just completed. Cross-sell products must be <a href="%s">configured in WooCommerce</a> first.', 'woocommerce-gateway-klarna' ), 'https://docs.woocommerce.com/document/related-products-up-sells-and-cross-sells/' ),
 		'default'     => 'no'
 	),
+	'filter_is_order_received' => array(
+		'title'       => __( 'Overwrite is_order_received_page to return true in Klarna thank you page', 'woocommerce-gateway-klarna' ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Several other plugins rely on is_order_received_page() function returning true in WooCommerce thank you page. Checking this option will make sure is_order_received_page() returns true in Klarna\'s custom thank you page as well.', 'woocommerce-gateway-klarna' ),
+		'default'     => 'no'
+	),
 
 	'color_settings_title'     => array(
 		'title' => __( 'Color Settings', 'woocommerce-gateway-klarna' ),

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      http://woothemes.com/woocommerce
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.2.2
+ * Version:         2.2.3
  * Author:          WooThemes
  * Author URI:      http://woothemes.com/
  * Developer:       Krokedil


### PR DESCRIPTION
* Fix - Fixes the error in settings page when using Klarna and MasterPass plugins together.
* Update - Disables Klarna Checkout autofocus on mobile.
* Fix - Adds Klarna Checkout setting that allows is_order_received_page() to return true on KCO thank you page.
* Fix - Adds JS fix for duplicate order items in KCO.
* Update - Adds only_shipping="yes" attribute to woocommerce_klarna_checkout_widget shortcode allowing it to only show shipping.