### PR TITLE
Extend the purge time

### DIFF
--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -327,7 +327,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			'posts_per_page' => - 1,
 			'date_query'     => array(
 				array(
-					'before' => '1 day ago'
+					'before' => '2 days ago'
 				)
 			)
 		);


### PR DESCRIPTION
Since Klarna is trying to send callbacks for 48 hours we should wait that time before deleting the order.