### PR TITLE
v2.3

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,6 +10,10 @@
 
 -
 
+### Klarna plugin version
+
+-
+
 ### WordPress version
 
 -

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ftpsync.settings
 .idea
-/.DS_Store
+.DS_Store
+/.gitignore

--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -173,29 +173,27 @@ jQuery(document).ready(function ($) {
 
 			new_country = $(this).val();
 
-			$.ajax(
-				kcoAjax.ajaxurl,
-				{
-					type: 'POST',
-					dataType: 'json',
-					data: {
-						action: 'klarna_checkout_country_callback',
-						new_country: new_country,
-						nonce: kcoAjax.klarna_checkout_nonce
-					},
-					success: function (response) {
-						document.location.assign(response.data.new_url);
-					},
-					error: function (response) {
-						console.log('select euro country AJAX error');
-						console.log(response);
-					},
-					complete: function () {
-						performingAjax = false;
-						unblockCartWidget();
-					}
+			$.ajaxq('KCOQueue', {
+				url: kcoAjax.ajaxurl,
+				type: 'POST',
+				dataType: 'json',
+				data: {
+					action: 'klarna_checkout_country_callback',
+					new_country: new_country,
+					nonce: kcoAjax.klarna_checkout_nonce
+				},
+				success: function (response) {
+					document.location.assign(response.data.new_url);
+				},
+				error: function (response) {
+					console.log('select euro country AJAX error');
+					console.log(response);
+				},
+				complete: function () {
+					performingAjax = false;
+					unblockCartWidget();
 				}
-			);
+			});
 		}
 	});
 
@@ -213,9 +211,9 @@ jQuery(document).ready(function ($) {
 
 			order_note = $(this).val();
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -260,9 +258,9 @@ jQuery(document).ready(function ($) {
 
 			$(document.body).trigger('kco_widget_update_shipping', new_method);
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -309,9 +307,9 @@ jQuery(document).ready(function ($) {
 			new_quantity = $(this).val();
 			kco_widget = $('#klarna-checkout-widget');
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -360,9 +358,9 @@ jQuery(document).ready(function ($) {
 			kco_widget = $('#klarna-checkout-widget');
 			cart_item_key_remove = $(ancestor).data('cart_item_key');
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -421,9 +419,9 @@ jQuery(document).ready(function ($) {
 			kco_widget = $('#klarna-checkout-widget');
 			input_field = $(this).find('#coupon_code');
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -487,9 +485,9 @@ jQuery(document).ready(function ($) {
 			clicked_el = $(this);
 			kco_widget = $('#klarna-checkout-widget');
 
-			$.ajax(
-				kcoAjax.ajaxurl,
+			$.ajaxq('KCOQueue',
 				{
+					url: kcoAjax.ajaxurl,
 					type: 'POST',
 					dataType: 'json',
 					data: {
@@ -667,9 +665,9 @@ jQuery(document).ready(function ($) {
 
 								kco_widget = $('#klarna-checkout-widget');
 
-								$.ajax(
-									kcoAjax.ajaxurl,
+								$.ajaxq('KCOQueue',
 									{
+										url: kcoAjax.ajaxurl,
 										type: 'POST',
 										dataType: 'json',
 										data: {
@@ -705,9 +703,9 @@ jQuery(document).ready(function ($) {
 					new_method = data.id;
 					kco_widget = $('#klarna-checkout-widget');
 
-					$.ajax(
-						kcoAjax.ajaxurl,
+					$.ajaxq('KCOQueue',
 						{
+							url: kcoAjax.ajaxurl,
 							type: 'POST',
 							dataType: 'json',
 							data: {

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 2017.02.xx  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.
+* Update    - Stores shipping phone number as order meta field in KCO notification listener.
+* Fix       - Adds trailinglashit to compared URLs in KCO enqueue scripts function.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Update    - Updates WordPress plugin header.
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.
 * Fix       - Adds trailinglashit to compared URLs in KCO enqueue scripts function.
+* Fix       - Fixes order note not being stored into WooCommerce order for KCO.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.02.xx  - version 2.3
+* Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
+* Update    - Updates WordPress plugin header.
+
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.02.xx  - version 2.3
+2017.02.21  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.
@@ -10,6 +10,7 @@
 * Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
 * Fix       - Fixes shipping order line item details for subscription orders for KCO.
 * Fix       - Adds an argument to woocommerce_cart_item_quantity filter.
+* Fix       - Fixes tax rate rounding issue for KCO V2 recurring orders.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,11 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2016.12.xx  - version 2.2.5
+2016.12.23  - version 2.2.5
 * Fix       - Uses correct credentials for Get Address feature.
+* Fix       - Fixes missing address issue on order update.
+* Update    - Changes login URL to go to My Account page.
+* Update    - Adds kco_widget_before_cart_total action hook before cart totals in KCO cart widget.
+* Update    - Adds klarna_process_cart_contents filter hook.
 
 2016.12.20  - version 2.2.4
 * Fix       - Fixes character encoding issue in customer address on order update.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@
 * Fix       - Adds trailinglashit to compared URLs in KCO enqueue scripts function.
 * Fix       - Fixes order note not being stored into WooCommerce order for KCO.
 * Fix       - Fixes MonsterInsights support.
+* Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
+* Fix       - Fixes shipping order line item details for subscription orders for KCO.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.02.21  - version 2.3
+2017.02.22  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2016.12.29  - version 2.2.6
+* Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.
+
 2016.12.23  - version 2.2.5
 * Fix       - Uses correct credentials for Get Address feature.
 * Fix       - Fixes missing address issue on order update.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix       - Fixes MonsterInsights support.
 * Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
 * Fix       - Fixes shipping order line item details for subscription orders for KCO.
+* Fix       - Adds an argument to woocommerce_cart_item_quantity filter.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.
 * Fix       - Adds trailinglashit to compared URLs in KCO enqueue scripts function.
 * Fix       - Fixes order note not being stored into WooCommerce order for KCO.
+* Fix       - Fixes MonsterInsights support.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -570,26 +570,26 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 					}
 					$recurring_price = $order->get_item_total( $item, true ) * 100;
 					if ( $item['line_total'] > 0 ) {
-						$recurring_tax_rate = ( $item['line_tax'] / $item['line_total'] ) * 10000;
+						$recurring_tax_rate = round( ( $item['line_tax'] / $item['line_total'] ) * 10000 );
 					} else {
 						$recurring_tax_rate = 0;
 					}
 					$cart[] = array(
 						'reference'     => strval( $reference ),
 						'name'          => utf8_decode( $item['name'] ),
-						'quantity'      => (int) $item['qty'],
-						'unit_price'    => (int) $recurring_price,
+						'quantity'      => intval( $item['qty'] ),
+						'unit_price'    => intval( $recurring_price ),
 						'discount_rate' => 0,
-						'tax_rate'      => (int) $recurring_tax_rate
+						'tax_rate'      => intval( $recurring_tax_rate )
 					);
 				}
 			}
 		}
 		// Shipping
 		if ( $order->get_total_shipping() > 0 ) {
-			$shipping_price = ( $order->get_total_shipping() + $order->get_shipping_tax() ) * 100;
+			$shipping_price = round(( $order->get_total_shipping() + $order->get_shipping_tax() ) * 100);
 			if ( $order->get_total_shipping() > 0 ) {
-				$shipping_tax_rate = ( $order->get_shipping_tax() / $order->get_total_shipping() ) * 10000;
+				$shipping_tax_rate = round( $order->get_shipping_tax() / $order->get_total_shipping() * 10000 );
 			} else {
 				$shipping_tax_rate = 0;
 			}
@@ -598,8 +598,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				'reference'  => 'SHIPPING',
 				'name'       => __( 'Shipping Fee', 'woocommerce-gateway-klarna' ),
 				'quantity'   => 1,
-				'unit_price' => (int) $shipping_price,
-				'tax_rate'   => (int) $shipping_tax_rate
+				'unit_price' => intval( $shipping_price ),
+				'tax_rate'   => intval( $shipping_tax_rate )
 			);
 		}
 		$create = array();

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -2054,7 +2054,6 @@ class WC_Gateway_Klarna_Checkout_Extra {
 	 * @since  2.0
 	 **/
 	function klarna_checkout_enqueuer() {
-		global $woocommerce;
 		$suffix               = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 		$assets_path          = str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/';
 		$frontend_script_path = $assets_path . 'js/frontend/';
@@ -2072,8 +2071,8 @@ class WC_Gateway_Klarna_Checkout_Extra {
 			'coupon_fail'           => __( 'Coupon could not be added.', 'woocommerce-gateway-klarna' )
 		) );
 		wp_register_style( 'klarna_checkout', KLARNA_URL . 'assets/css/klarna-checkout.css', array(), WC_KLARNA_VER );
+
 		if ( is_page() ) {
-			global $post;
 			$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 			$checkout_pages    = array();
 			$thank_you_pages   = array();
@@ -2088,12 +2087,12 @@ class WC_Gateway_Klarna_Checkout_Extra {
 				foreach ( $checkout_settings as $cs_key => $cs_value ) {
 					if ( strpos( $cs_key, 'klarna_checkout_url_' ) !== false && '' != $cs_value ) {
 						$clean_checkout_uri = explode( '?', $cs_value );
-						$clean_checkout_uri = $clean_checkout_uri[0];
+						$clean_checkout_uri = trailingslashit( $clean_checkout_uri[0] );
 						$checkout_pages[ $cs_key ] = substr( $clean_checkout_uri, 0 - $length );
 					}
 					if ( strpos( $cs_key, 'klarna_checkout_thanks_url_' ) !== false && '' != $cs_value ) {
 						$clean_thank_you_uri = explode( '?', $cs_value );
-						$clean_thank_you_uri = $clean_thank_you_uri[0];
+						$clean_thank_you_uri = trailingslashit( $clean_thank_you_uri[0] );
 						$thank_you_pages[ $cs_key ] = substr( $clean_thank_you_uri, 0 - $length );
 					}
 				}

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -446,7 +446,7 @@ class WC_Gateway_Klarna_Shortcodes {
 							'min_value'   => '1'
 						), $_product, false );
 					}
-					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key );
+					echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
 					echo '</td>';
 					echo '<td class="product-total kco-rightalign"><span class="amount">';
 					echo apply_filters( 'woocommerce_cart_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key );

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -594,12 +594,18 @@ class WC_Gateway_Klarna_K2WC {
 		}
 
 		// Add customer billing address - retrieved from callback from Klarna.
-		$billing_care_of = isset( $klarna_order['billing_address']['care_of'] ) ? $klarna_order['billing_address']['care_of'] : '';
+		if ( isset( $klarna_order['billing_address']['care_of'] ) ) {
+			$billing_address_2 = $klarna_order['billing_address']['care_of'];
+		} elseif ( isset( $klarna_order['billing_address']['street_address2'] ) ) {
+			$billing_address_2 = $klarna_order['billing_address']['street_address2'];
+		} else {
+			$billing_address_2 = '';
+		}
 		$billing_address = array(
 			'first_name' => $klarna_order['billing_address']['given_name'],
 			'last_name'  => $klarna_order['billing_address']['family_name'],
 			'address_1'  => $received__billing_address_1,
-			'address_2'  => $billing_care_of,
+			'address_2'  => $billing_address_2,
 			'postcode'   => $klarna_order['billing_address']['postal_code'],
 			'city'       => $klarna_order['billing_address']['city'],
 			'country'    => strtoupper( $klarna_order['billing_address']['country'] ),
@@ -617,12 +623,18 @@ class WC_Gateway_Klarna_K2WC {
 
 		$order->set_address( apply_filters( 'wc_klarna_returned_billing_address', $billing_address ), 'billing' );
 
-		$shipping_care_of = isset( $klarna_order['shipping_address']['care_of'] ) ? $klarna_order['shipping_address']['care_of'] : '';
+		if ( isset( $klarna_order['shipping_address']['care_of'] ) ) {
+			$shipping_address_2 = $klarna_order['shipping_address']['care_of'];
+		} elseif ( isset( $klarna_order['shipping_address']['street_address2'] ) ) {
+			$shipping_address_2 = $klarna_order['shipping_address']['street_address2'];
+		} else {
+			$shipping_address_2 = '';
+		}
 		$shipping_address = array(
 			'first_name' => $klarna_order['shipping_address']['given_name'],
 			'last_name'  => $klarna_order['shipping_address']['family_name'],
 			'address_1'  => $received__shipping_address_1,
-			'address_2'  => $shipping_care_of,
+			'address_2'  => $shipping_address_2,
 			'postcode'   => $klarna_order['shipping_address']['postal_code'],
 			'city'       => $klarna_order['shipping_address']['city'],
 			'country'    => strtoupper( $klarna_order['shipping_address']['country'] ),

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -326,7 +326,7 @@ class WC_Gateway_Klarna_K2WC {
 			$order->calculate_totals( false );
 
 			// Other plugins need this hook.
-			do_action( 'woocommerce_checkout_order_processed', $order->id, false );
+			// do_action( 'woocommerce_checkout_order_processed', $order->id, false );
 
 			// Process subscriptions for order.
 			if ( class_exists( 'WC_Subscriptions_Checkout' ) && get_post_meta( $order->id, '_klarna_recurring_carts', true ) ) {

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -656,6 +656,7 @@ class WC_Gateway_Klarna_K2WC {
 			'postcode'   => $klarna_order['shipping_address']['postal_code'],
 			'city'       => $klarna_order['shipping_address']['city'],
 			'country'    => strtoupper( $klarna_order['shipping_address']['country'] ),
+			'phone'      => $klarna_order['shipping_address']['phone'],
 		);
 
 		// Company.

--- a/classes/class-wc-to-klarna.php
+++ b/classes/class-wc-to-klarna.php
@@ -671,12 +671,12 @@ class WC_Gateway_Klarna_WC2K {
 		global $woocommerce;
 
 		if ( 'us' == $this->klarna_country ) {
-			$shipping_amount = (int) number_format( $woocommerce->cart->shipping_total * 100, 0, '', '' );
+			$shipping_amount = $woocommerce->cart->shipping_total;
 		} else {
-			$shipping_amount = (int) number_format( ( $woocommerce->cart->shipping_total + $woocommerce->cart->shipping_tax_total ) * 100, 0, '', '' );
+			$shipping_amount = $woocommerce->cart->shipping_total + $woocommerce->cart->shipping_tax_total;
 		}
 
-		return (int) $shipping_amount;
+		return round( $shipping_amount * 100 );
 	}
 
 	/**

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -129,14 +129,54 @@ if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 	 */
 	$orderid = $this->update_or_create_local_order();
 
-	// Add GA cookie as custom field for GA Ecommerce plugin
+	// Add GA cookie as custom field for GA Ecommerce plugin.
 	if ( class_exists( 'Yoast_GA_Woo_eCommerce_Tracking' ) && isset( $_COOKIE['_ga'] ) ) {
 		// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
 		// so strip the version number.
 		$cookie = preg_replace( '/^(GA\d\.\d\.)/', '', $_COOKIE['_ga'] );
-
 		update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
 	}
+
+	// Add GA cookie as custom field for GA Ecommerce plugin.
+	if ( class_exists( 'MonsterInsights_eCommerce' ) && isset( $_COOKIE['_ga'] ) ) {
+		// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
+		// so strip the version number.
+		$cookie       = '';
+		$ga_cookie    = $_COOKIE['_ga'];
+		$cookie_parts = explode( '.', $ga_cookie );
+		if ( is_array( $cookie_parts ) && ! empty( $cookie_parts[2] ) && ! empty( $cookie_parts[3] ) ) {
+			$uuid = (string) $cookie_parts[2] . '.' . (string) $cookie_parts[3];
+			if ( is_string( $uuid ) ) {
+				$cookie = $uuid;
+			} else {
+				$cookie = false;
+			}
+		} else {
+			$cookie = false;
+		}
+		update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
+
+		$cookie = '';
+		if ( empty( $_COOKIE['_ga'] ) ) {
+			$cookie = 'FCE';
+		} else {
+			$ga_cookie    = $_COOKIE['_ga'];
+			$cookie_parts = explode( '.', $ga_cookie );
+			if ( is_array( $cookie_parts ) && ! empty( $cookie_parts[2] ) && ! empty( $cookie_parts[3] ) ) {
+				$uuid = (string) $cookie_parts[2] . '.' . (string) $cookie_parts[3];
+				if ( is_string( $uuid ) ) {
+					$cookie = $ga_cookie;
+				} else {
+					$cookie = 'FA';
+				}
+			} else {
+				$cookie = 'FAE';
+			}
+		}
+		update_post_meta( $orderid, '_monsterinsights_cookie', $cookie );
+	}
+
+
 
 	// WC Subscriptions 2.0 needs this
 	if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -79,6 +79,7 @@ if ( $this->is_rest() ) {
 	$snippet = '<div class="klarna-thank-you-snippet">' . $klarna_order['gui']['snippet'] . '</div>';
 }
 
+do_action( 'woocommerce_checkout_order_processed', intval( $_GET['sid'] ), false );
 do_action( 'klarna_before_kco_confirmation', intval( $_GET['sid'] ) );
 
 echo $snippet;

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -79,6 +79,9 @@ if ( $this->is_rest() ) {
 	$snippet = '<div class="klarna-thank-you-snippet">' . $klarna_order['gui']['snippet'] . '</div>';
 }
 
+// Need to calculate totals because of woocommerce_checkout_order_processed hook below, plugins like WCS need totals calculated.
+WC()->cart->calculate_shipping();
+WC()->cart->calculate_totals();
 do_action( 'woocommerce_checkout_order_processed', intval( $_GET['sid'] ), false );
 do_action( 'klarna_before_kco_confirmation', intval( $_GET['sid'] ) );
 
@@ -92,4 +95,4 @@ WC()->session->__unset( 'klarna_checkout' );
 WC()->session->__unset( 'klarna_checkout_country' );
 WC()->session->__unset( 'ongoing_klarna_order' );
 WC()->session->__unset( 'klarna_order_note' );
-WC()->cart->empty_cart(); // Remove cart
+wc_clear_cart_after_payment(); // Clear cart.

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -2,23 +2,23 @@
 /**
  * WooCommerce Klarna Gateway
  *
- * @link http://www.woothemes.com/products/klarna/
+ * @link https://woocommerce.com/products/klarna/
  * @since 0.3
  *
  * @package WC_Gateway_Klarna
  *
  * @wordpress-plugin
  * Plugin Name:     WooCommerce Klarna Gateway
- * Plugin URI:      http://woothemes.com/woocommerce
+ * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.2.6
- * Author:          WooThemes
- * Author URI:      http://woothemes.com/
+ * Version:         2.3
+ * Author:          WooCommerce
+ * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
  * Developer URI:   http://krokedil.com/
  * Text Domain:     woocommerce-gateway-klarna
  * Domain Path:     /languages
- * Copyright:       © 2009-2015 WooThemes.
+ * Copyright:       © 2009-2017 WooCommerce.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( !defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.2.6' );
+	define( 'WC_KLARNA_VER', '2.3' );
 }
 
 /**

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      http://woothemes.com/woocommerce
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.2.5
+ * Version:         2.2.6
  * Author:          WooThemes
  * Author URI:      http://woothemes.com/
  * Developer:       Krokedil
@@ -24,11 +24,11 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit; // Exit if accessed directly
 }
 
-if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.2.5' );
+if ( !defined( 'WC_KLARNA_VER' ) ) {
+	define( 'WC_KLARNA_VER', '2.2.6' );
 }
 
 /**

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -24,10 +24,10 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-if ( !defined( 'WC_KLARNA_VER' ) ) {
+if ( ! defined( 'WC_KLARNA_VER' ) ) {
 	define( 'WC_KLARNA_VER', '2.2.5' );
 }
 


### PR DESCRIPTION
* Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
* Update    - Updates WordPress plugin header.
* Update    - Stores shipping phone number as order meta field in KCO notification listener.
* Fix       - Adds trailinglashit to compared URLs in KCO enqueue scripts function.
* Fix       - Fixes order note not being stored into WooCommerce order for KCO.
* Fix       - Fixes MonsterInsights support.
* Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
* Fix       - Fixes shipping order line item details for subscription orders for KCO.
* Fix       - Adds an argument to woocommerce_cart_item_quantity filter.
* Fix       - Fixes tax rate rounding issue for KCO V2 recurring orders.