### PR TITLE
v2.3.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.03.xx  - version 2.3.1
+* Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.
+
 2017.02.22  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.03.xx  - version 2.3.1
+2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.
 
 2017.02.22  - version 2.3

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -231,7 +231,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 * @throws Exception
 	 */
 	function finalize_subscription( $subscription, $order, $cart ) {
-		if ( $this->id === $subscription->payment_method && empty( $subscription->get_shipping_methods() ) ) {
+		$subscription_shipping_methods = $subscription->get_shipping_methods();
+		if ( $this->id === $subscription->payment_method && empty( $subscription_shipping_methods ) ) {
 			WC_Subscriptions_Cart::set_calculation_type( 'recurring_total' );
 
 			foreach ( $cart->get_shipping_packages() as $base_package ) {

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.3
+ * Version:         2.3.1
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( !defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.3' );
+	define( 'WC_KLARNA_VER', '2.3.1' );
 }
 
 /**


### PR DESCRIPTION
* Fix - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.