### PR TITLE
2.3.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.03.xx  - version 2.3.2
+* Fix       - Fixed compatibility with WooCommerce Min/Max plugin.
+
 2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.03.xx  - version 2.3.1
+* Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.
+
 2017.02.22  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.02.xx  - version 2.3
+2017.02.21  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.
@@ -10,6 +10,7 @@
 * Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
 * Fix       - Fixes shipping order line item details for subscription orders for KCO.
 * Fix       - Adds an argument to woocommerce_cart_item_quantity filter.
+* Fix       - Fixes tax rate rounding issue for KCO V2 recurring orders.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.02.21  - version 2.3
+2017.02.22  - version 2.3
 * Fix       - Moves woocommerce_checkout_order_processed from notification listener to thank you page (AWP and GA plugins fix).
 * Update    - Updates WordPress plugin header.
 * Update    - Stores shipping phone number as order meta field in KCO notification listener.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 2017.03.xx  - version 2.3.2
 * Fix       - Fixed compatibility with WooCommerce Min/Max plugin.
 * Fix       - Fixed compatibility with Subscriptions/Memberships combination of plugins.
+* Fix       - Adds support for KCO NL.
+* Fix       - Fixes order total calculation when shipping doesn't have tax for KCO.
 
 2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix       - Fixes MonsterInsights support.
 * Fix       - Fixes address line 2 not being stored in WooCommerce orders for KCO UK.
 * Fix       - Fixes shipping order line item details for subscription orders for KCO.
+* Fix       - Adds an argument to woocommerce_cart_item_quantity filter.
 
 2016.12.29  - version 2.2.6
 * Fix       - Uses AjaxQ library (MIT license: https://foliotek.github.io/AjaxQ/) to fix duplicate order items issue.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,15 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.03.xx  - version 2.3.2
+2017.03.23  - version 2.3.2
 * Fix       - Fixed compatibility with WooCommerce Min/Max plugin.
 * Fix       - Fixed compatibility with Subscriptions/Memberships combination of plugins.
 * Fix       - Adds support for KCO NL.
+* Fix       - Fixes tax rate calculation in refunds for KCO V2.
 * Fix       - Fixes order total calculation when shipping doesn't have tax for KCO.
+* Fix       - Fixes WooCommerce order total calculation when coupons are used in KCO V3.
+* Fix       - Adds utf8_encode to refund reason.
+* Update    - Adds klarna_is_rest_countries_eu and klarna_is_rest_countries_na filters.
+* Update    - Stores Klarna credentials country as order meta field.
 
 2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.03.xx  - version 2.3.1
+2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.
 
 2017.02.22  - version 2.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2017.03.xx  - version 2.3.2
 * Fix       - Fixed compatibility with WooCommerce Min/Max plugin.
+* Fix       - Fixed compatibility with Subscriptions/Memberships combination of plugins.
 
 2017.03.06  - version 2.3.1
 * Fix       - Fixes "Can't use method return value in write context" error for PHP <= 5.4 in KCO class.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -231,7 +231,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 * @throws Exception
 	 */
 	function finalize_subscription( $subscription, $order, $cart ) {
-		if ( $this->id === $subscription->payment_method && empty( $subscription->get_shipping_methods() ) ) {
+		$subscription_shipping_methods = $subscription->get_shipping_methods();
+		if ( $this->id === $subscription->payment_method && empty( $subscription_shipping_methods ) ) {
 			WC_Subscriptions_Cart::set_calculation_type( 'recurring_total' );
 
 			foreach ( $cart->get_shipping_packages() as $base_package ) {

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1539,6 +1539,11 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			$order_id = sanitize_key( $_GET['sid'] );
 			$klarna_credentials_country =  get_post_meta( $order_id, '_klarna_credentials_country', true );
 			
+			// Hack for UK/GB. We store the settings as UK but Klarna is using GB
+			if( 'gb' == strtolower( $klarna_credentials_country ) ) {
+				$klarna_credentials_country = 'uk';
+			}
+			
 			if( $klarna_credentials_country ) {
 				$klarna_credentials_country	= strtolower( $klarna_credentials_country );
 				$klarna_eid          		= $this->settings["eid_$klarna_credentials_country"];

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1120,20 +1120,21 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 
 		if ( $this->is_rest() ) {
 			if ( $this->testmode == 'yes' ) {
-				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 				} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 				}
 			} else {
-				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
 				} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 				}
 			}
+			$klarna_order_id = WC()->session->get( 'klarna_checkout' );
 			$connector    = Klarna\Rest\Transport\Connector::create( $eid, $sharedSecret, $klarna_server_url );
-			$klarna_order = new \Klarna\Rest\Checkout\Order( $connector, WC()->session->get( 'klarna_checkout' ) );
+			$klarna_order = new \Klarna\Rest\Checkout\Order( $connector, $klarna_order_id );
 		} else {
 			$connector    = Klarna_Checkout_Connector::create( $sharedSecret, $this->klarna_server );
 			$klarna_order = new Klarna_Checkout_Order( $connector, WC()->session->get( 'klarna_checkout' ) );

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -570,26 +570,26 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 					}
 					$recurring_price = $order->get_item_total( $item, true ) * 100;
 					if ( $item['line_total'] > 0 ) {
-						$recurring_tax_rate = ( $item['line_tax'] / $item['line_total'] ) * 10000;
+						$recurring_tax_rate = round( ( $item['line_tax'] / $item['line_total'] ) * 10000 );
 					} else {
 						$recurring_tax_rate = 0;
 					}
 					$cart[] = array(
 						'reference'     => strval( $reference ),
 						'name'          => utf8_decode( $item['name'] ),
-						'quantity'      => (int) $item['qty'],
-						'unit_price'    => (int) $recurring_price,
+						'quantity'      => intval( $item['qty'] ),
+						'unit_price'    => intval( $recurring_price ),
 						'discount_rate' => 0,
-						'tax_rate'      => (int) $recurring_tax_rate
+						'tax_rate'      => intval( $recurring_tax_rate )
 					);
 				}
 			}
 		}
 		// Shipping
 		if ( $order->get_total_shipping() > 0 ) {
-			$shipping_price = ( $order->get_total_shipping() + $order->get_shipping_tax() ) * 100;
+			$shipping_price = round(( $order->get_total_shipping() + $order->get_shipping_tax() ) * 100);
 			if ( $order->get_total_shipping() > 0 ) {
-				$shipping_tax_rate = ( $order->get_shipping_tax() / $order->get_total_shipping() ) * 10000;
+				$shipping_tax_rate = round( $order->get_shipping_tax() / $order->get_total_shipping() * 10000 );
 			} else {
 				$shipping_tax_rate = 0;
 			}
@@ -598,8 +598,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				'reference'  => 'SHIPPING',
 				'name'       => __( 'Shipping Fee', 'woocommerce-gateway-klarna' ),
 				'quantity'   => 1,
-				'unit_price' => (int) $shipping_price,
-				'tax_rate'   => (int) $shipping_tax_rate
+				'unit_price' => intval( $shipping_price ),
+				'tax_rate'   => intval( $shipping_tax_rate )
 			);
 		}
 		$create = array();

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1779,7 +1779,13 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				$klarna_order = new WC_Gateway_Klarna_Order( $order, $klarna );
 				$refund_order = $klarna_order->refund_order( $amount, $reason, $invNo );
 			} elseif ( 'rest' == get_post_meta( $order->id, '_klarna_api', true ) ) {
-				$country = get_post_meta( $orderid, '_billing_country', true );
+				
+				if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+					$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+				} else {
+					$country = get_post_meta( $orderid, '_billing_country', true );
+				}
+				
 				/**
 				 * Need to send local order to constructor and Klarna order to method
 				 */

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1106,16 +1106,16 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			if( in_array( strtoupper( $klarna_c ), array( 'DE', 'FI', 'NL' ) )  ) {
 				// Add correct EID & secret specific to country if the curency is EUR and the country is DE or FI.
 				$eid          = $this->settings["eid_$klarna_c"];
-				$sharedSecret = $this->settings["secret_$klarna_c"];
+				$sharedSecret = html_entity_decode ( $this->settings["secret_$klarna_c"] );
 			} else {
 				// Otherwise use the general eid and secret (filterable) if we're using EUR as currency for a global KCO checkout
 				$eid          = $this->klarna_eid;
-				$sharedSecret = $this->klarna_secret;
+				$sharedSecret = html_entity_decode ( $this->klarna_secret );
 			}
 			
 		} else {
 			$eid          = $this->klarna_eid;
-			$sharedSecret = $this->klarna_secret;
+			$sharedSecret = html_entity_decode ( $this->klarna_secret );
 		}
 
 		if ( $this->is_rest() ) {
@@ -1771,7 +1771,18 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 					}
 				}
 				if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
-					$connector = Klarna\Rest\Transport\Connector::create( $this->eid_uk, $this->secret_uk, $klarna_server_url );
+					if ( 'gb' === strtolower( $country ) ) {
+						$eid = $this->eid_uk;
+						$secret = html_entity_decode( $this->secret_uk );
+					} elseif ( 'dk' === strtolower( $country ) ) {
+						$eid = $this->eid_dk;
+						$secret = html_entity_decode( $this->secret_dk );
+					} elseif ( 'nl' === strtolower( $country ) ) {
+						$eid = $this->eid_nl;
+						$secret = html_entity_decode( $this->secret_nl );
+					}
+
+					$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
 				} elseif ( 'us' === strtolower( $country ) ) {
 					$connector = Klarna\Rest\Transport\Connector::create( $this->eid_us, $this->secret_us, $klarna_server_url );
 				}

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1511,6 +1511,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		$klarna_to_wc->set_klarna_debug( $this->debug );
 		$klarna_to_wc->set_klarna_test_mode( $this->testmode );
 		$klarna_to_wc->set_klarna_server( $this->klarna_server );
+		$klarna_to_wc->set_klarna_credentials_country( $this->klarna_credentials_country );
 		if ( $customer_email ) {
 			$orderid = $klarna_to_wc->prepare_wc_order( $customer_email );
 		} else {
@@ -1530,45 +1531,64 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		if ( isset( $_GET['validate'] ) ) {
 			exit;
 		}
-		switch ( $_GET['scountry'] ) {
-			case 'SE':
-				$klarna_secret = $this->secret_se;
-				$klarna_eid    = $this->eid_se;
-				break;
-			case 'FI' :
-				$klarna_secret = $this->secret_fi;
-				$klarna_eid    = $this->eid_se;
-				break;
-			case 'NO' :
-				$klarna_secret = $this->secret_no;
-				$klarna_eid    = $this->eid_no;
-				break;
-			case 'DE' :
-				$klarna_secret = $this->secret_de;
-				$klarna_eid    = $this->eid_de;
-				break;
-			case 'AT' :
-				$klarna_secret = $this->secret_at;
-				$klarna_eid    = $this->eid_at;
-				break;
-			case 'dk' :
-				$klarna_secret = $this->secret_dk;
-				$klarna_eid    = $this->eid_dk;
-				break;
-			case 'nl' :
-				$klarna_secret = $this->secret_nl;
-				$klarna_eid    = $this->eid_nl;
-				break;
-			case 'gb' :
-				$klarna_secret = $this->secret_uk;
-				$klarna_eid    = $this->eid_uk;
-				break;
-			case 'us' :
-				$klarna_secret = $this->secret_us;
-				$klarna_eid    = $this->eid_us;
-				break;
-			default:
-				$klarna_secret = '';
+		$klarna_eid = false;
+		$klarna_secret = false;
+		
+		// Retrieve Eid & Secret from order if it exist
+		if ( isset( $_GET['sid'] ) ) {
+			$order_id = sanitize_key( $_GET['sid'] );
+			$klarna_credentials_country =  get_post_meta( $order_id, '_klarna_credentials_country', true );
+			
+			if( $klarna_credentials_country ) {
+				$klarna_credentials_country	= strtolower( $klarna_credentials_country );
+				$klarna_eid          		= $this->settings["eid_$klarna_credentials_country"];
+				$klarna_secret 				= html_entity_decode ( $this->settings["secret_$klarna_credentials_country"] );
+			}
+		}
+		
+		// If we don't get an Eid from the order then we can grab the data from the returned country
+		// @TODO - this can be removed over time since the credential country now is stored as post meta in the order.
+		if( empty( $klarna_eid ) ) {
+			switch ( $_GET['scountry'] ) {
+				case 'SE':
+					$klarna_secret = $this->secret_se;
+					$klarna_eid    = $this->eid_se;
+					break;
+				case 'FI' :
+					$klarna_secret = $this->secret_fi;
+					$klarna_eid    = $this->eid_se;
+					break;
+				case 'NO' :
+					$klarna_secret = $this->secret_no;
+					$klarna_eid    = $this->eid_no;
+					break;
+				case 'DE' :
+					$klarna_secret = $this->secret_de;
+					$klarna_eid    = $this->eid_de;
+					break;
+				case 'AT' :
+					$klarna_secret = $this->secret_at;
+					$klarna_eid    = $this->eid_at;
+					break;
+				case 'dk' :
+					$klarna_secret = $this->secret_dk;
+					$klarna_eid    = $this->eid_dk;
+					break;
+				case 'nl' :
+					$klarna_secret = $this->secret_nl;
+					$klarna_eid    = $this->eid_nl;
+					break;
+				case 'gb' :
+					$klarna_secret = $this->secret_uk;
+					$klarna_eid    = $this->eid_uk;
+					break;
+				case 'us' :
+					$klarna_secret = $this->secret_us;
+					$klarna_eid    = $this->eid_us;
+					break;
+				default:
+					$klarna_secret = '';
+			}
 		}
 		// Process cart contents and prepare them for Klarna
 		if ( isset( $_GET['klarna_order'] ) ) {
@@ -1582,6 +1602,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			$klarna_to_wc->set_klarna_test_mode( $this->testmode );
 			$klarna_to_wc->set_klarna_debug( $this->debug );
 			$klarna_to_wc->set_klarna_server( $this->klarna_server );
+			$klarna_to_wc->set_klarna_credentials_country( $this->klarna_credentials_country );
 			$klarna_to_wc->listener();
 		}
 	} // End function check_checkout_listener

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1044,6 +1044,9 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			} elseif ( 'dnk' == $_REQUEST['country'] ) {
 				$woocommerce->customer->set_country( 'DK' );
 				$woocommerce->customer->set_shipping_country( 'DK' );
+			} elseif ( 'nld' == $_REQUEST['country'] ) {
+				$woocommerce->customer->set_country( 'NL' );
+				$woocommerce->customer->set_shipping_country( 'NL' );
 			}
 		}
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
@@ -1100,7 +1103,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		if ( 'EUR' == get_woocommerce_currency() && WC()->session->get( 'klarna_euro_country' ) ) {
 			$klarna_c     = strtolower( WC()->session->get( 'klarna_euro_country' ) );
 			
-			if( in_array( strtoupper( $klarna_c ), array( 'DE', 'FI' ) )  ) {
+			if( in_array( strtoupper( $klarna_c ), array( 'DE', 'FI', 'NL' ) )  ) {
 				// Add correct EID & secret specific to country if the curency is EUR and the country is DE or FI.
 				$eid          = $this->settings["eid_$klarna_c"];
 				$sharedSecret = $this->settings["secret_$klarna_c"];
@@ -1551,6 +1554,10 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				$klarna_secret = $this->secret_dk;
 				$klarna_eid    = $this->eid_dk;
 				break;
+			case 'nl' :
+				$klarna_secret = $this->secret_nl;
+				$klarna_eid    = $this->eid_nl;
+				break;
 			case 'gb' :
 				$klarna_secret = $this->secret_uk;
 				$klarna_eid    = $this->eid_uk;
@@ -1750,21 +1757,21 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				 * Need to send local order to constructor and Klarna order to method
 				 */
 				if ( $this->testmode == 'yes' ) {
-					if ( 'gb' == strtolower( $country ) || 'dk' == strtolower( $country ) ) {
+					if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 						$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-					} elseif ( 'us' == strtolower( $country ) ) {
+					} elseif ( 'us' === strtolower( $country ) ) {
 						$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 					}
 				} else {
-					if ( 'gb' == strtolower( $country ) || 'dk' == strtolowe( $country ) ) {
+					if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 						$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-					} elseif ( 'us' == strtolower( $country ) ) {
+					} elseif ( 'us' === strtolower( $country ) ) {
 						$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 					}
 				}
-				if ( 'gb' == strtolower( $country ) || 'dk' == strtolower( $country ) ) {
+				if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 					$connector = Klarna\Rest\Transport\Connector::create( $this->eid_uk, $this->secret_uk, $klarna_server_url );
-				} elseif ( 'us' == strtolower( $country ) ) {
+				} elseif ( 'us' === strtolower( $country ) ) {
 					$connector = Klarna\Rest\Transport\Connector::create( $this->eid_us, $this->secret_us, $klarna_server_url );
 				}
 				$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );
@@ -1788,7 +1795,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 * @since  2.0.0
 	 */
 	function is_rest() {
-		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries', array( 'US', 'DK', 'GB' ) ) ) ) {
+		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries', array( 'US', 'DK', 'GB', 'NL' ) ) ) ) {
 			// Set it in session as well, to be used in Shortcodes class
 			WC()->session->set( 'klarna_is_rest', true );
 
@@ -2238,7 +2245,7 @@ class WC_Gateway_Klarna_Checkout_Extra {
 	 */
 	function is_rest() {
 		$this->klarna_country = WC()->session->get( 'klarna_country' );
-		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries', array( 'US', 'DK', 'GB' ) ) ) ) {
+		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries', array( 'US', 'DK', 'GB', 'NL' ) ) ) ) {
 			// Set it in session as well, to be used in Shortcodes class
 			WC()->session->set( 'klarna_is_rest', true );
 

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1102,7 +1102,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		// Check if Euro is selected, get correct country
 		if ( 'EUR' == get_woocommerce_currency() && WC()->session->get( 'klarna_euro_country' ) ) {
 			$klarna_c     = strtolower( WC()->session->get( 'klarna_euro_country' ) );
-			
+
 			if( in_array( strtoupper( $klarna_c ), array( 'DE', 'FI', 'NL' ) )  ) {
 				// Add correct EID & secret specific to country if the curency is EUR and the country is DE or FI.
 				$eid          = $this->settings["eid_$klarna_c"];
@@ -1112,7 +1112,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				$eid          = $this->klarna_eid;
 				$sharedSecret = html_entity_decode ( $this->klarna_secret );
 			}
-			
+
 		} else {
 			$eid          = $this->klarna_eid;
 			$sharedSecret = html_entity_decode ( $this->klarna_secret );

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -558,8 +558,13 @@ class WC_Gateway_Klarna_Order {
 		$order = wc_get_order( $orderid );
 		if ( get_post_meta( $orderid, '_klarna_order_reservation', true ) && get_post_meta( $orderid, '_billing_country', true ) ) {
 			$rno            = get_post_meta( $orderid, '_klarna_order_reservation', true );
-			$country        = get_post_meta( $orderid, '_billing_country', true );
 			$payment_method = get_post_meta( $orderid, '_payment_method', true );
+			// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+			if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+				$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+			} else {
+				$country = get_post_meta( $orderid, '_billing_country', true );
+			}
 			// Check if this is a subscription order
 			if ( class_exists( 'WC_Subscriptions_Renewal_Order' ) && WC_Subscriptions_Renewal_Order::is_renewal( $order ) ) {
 				if ( ! get_post_meta( $orderid, '_klarna_order_reservation_recurring', true ) ) {
@@ -595,36 +600,41 @@ class WC_Gateway_Klarna_Order {
 	function activate_order_rest( $orderid ) {
 		$order           = wc_get_order( $orderid );
 		$klarna_settings = get_option( 'woocommerce_klarna_checkout_settings' );
-		$billing_country = get_post_meta( $orderid, '_billing_country', true );
+		// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+		if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+			$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+		} else {
+			$country = get_post_meta( $orderid, '_billing_country', true );
+		}
 		/**
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			if ( 'gb' === strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
+			if ( 'gb' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_uk'];
 				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
-			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+			} elseif ( 'dk' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_dk'];
 				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
-			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+			} elseif ( 'nl' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_nl'];
 				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
 			}
 			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
-		} elseif ( 'us' === strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );
@@ -690,7 +700,12 @@ class WC_Gateway_Klarna_Order {
 		// Klarna reservation number and billing country must be set
 		if ( get_post_meta( $orderid, '_klarna_order_reservation', true ) && get_post_meta( $orderid, '_billing_country', true ) && ! get_post_meta( $orderid, '_klarna_order_activated', true ) ) {
 			$rno            = get_post_meta( $orderid, '_klarna_order_reservation', true );
-			$country        = get_post_meta( $orderid, '_billing_country', true );
+			// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+			if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+				$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+			} else {
+				$country = get_post_meta( $orderid, '_billing_country', true );
+			}
 			$payment_method = get_post_meta( $orderid, '_payment_method', true );
 			$klarna = new Klarna();
 			$this->configure_klarna( $klarna, $country, $payment_method );
@@ -715,37 +730,42 @@ class WC_Gateway_Klarna_Order {
 	function cancel_order_rest( $orderid ) {
 		$order           = wc_get_order( $orderid );
 		$klarna_settings = get_option( 'woocommerce_klarna_checkout_settings' );
-		$billing_country = get_post_meta( $orderid, '_billing_country', true );
+		// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+		if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+			$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+		} else {
+			$country = get_post_meta( $orderid, '_billing_country', true );
+		}
 		/**
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			if ( 'gb' === strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
+			if ( 'gb' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_uk'];
 				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
-			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+			} elseif ( 'dk' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_dk'];
 				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
-			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+			} elseif ( 'nl' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_nl'];
 				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
 			}
 
 			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
-		} elseif ( 'us' === strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );
@@ -865,8 +885,13 @@ class WC_Gateway_Klarna_Order {
 		$order       = wc_get_order( $orderid );
 		$this->order = $order;
 		$rno            = get_post_meta( $orderid, '_klarna_order_reservation', true );
-		$country        = get_post_meta( $orderid, '_billing_country', true );
 		$payment_method = get_post_meta( $orderid, '_payment_method', true );
+		// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+		if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+			$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+		} else {
+			$country = get_post_meta( $orderid, '_billing_country', true );
+		}
 		$klarna = new Klarna();
 		$this->configure_klarna( $klarna, $country, $payment_method );
 		$this->klarna = $klarna;
@@ -903,7 +928,12 @@ class WC_Gateway_Klarna_Order {
 	function update_order_rest( $orderid, $itemid = false ) {
 		$order           = wc_get_order( $orderid );
 		$klarna_settings = get_option( 'woocommerce_klarna_checkout_settings' );
-		$billing_country = get_post_meta( $orderid, '_billing_country', true );
+		// Get country - either from stored _klarna_credentials_country or _billing_country (backwords compat)
+		if( get_post_meta( $orderid, '_klarna_credentials_country', true ) ) {
+			$country =  get_post_meta( $orderid, '_klarna_credentials_country', true );
+		} else {
+			$country = get_post_meta( $orderid, '_billing_country', true );
+		}
 		$updated_order_lines = array();
 		$updated_order_total = 0;
 		$updated_tax_total   = 0;
@@ -1062,32 +1092,32 @@ class WC_Gateway_Klarna_Order {
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' === strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			if ( 'gb' === strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $country ) || 'dk' === strtolower( $country ) || 'nl' === strtolower( $country ) ) {
+			if ( 'gb' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_uk'];
 				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
-			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+			} elseif ( 'dk' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_dk'];
 				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
-			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+			} elseif ( 'nl' === strtolower( $country ) ) {
 				$eid = $klarna_settings['eid_nl'];
 				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
 			}
 
 			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
-		} elseif ( 'us' === strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -352,11 +352,11 @@ class WC_Gateway_Klarna_Order {
 				$tax_rate = (int) ($order->get_total_tax() / ( $order->get_total() - $order->get_total_tax() ) * 100);
 				try {
 					$ocr = $klarna->returnAmount( // returns 1 on success
-						$invNo,               // Invoice number
-						$amount,              // Amount given as a discount.
-						$tax_rate,            // VAT (%)
-						KlarnaFlags::INC_VAT, // Amount including VAT.
-						$reason               // Description
+						$invNo,                // Invoice number
+						$amount,               // Amount given as a discount.
+						$tax_rate,             // VAT (%)
+						KlarnaFlags::INC_VAT,  // Amount including VAT.
+						utf8_encode( $reason ) // Description
 					);
 					if ( $ocr ) {
 						$order->add_order_note( sprintf( __( 'Klarna order partially refunded. Refund amount: %s.', 'woocommerce-gateway-klarna' ), wc_price( $amount, array( 'currency' => $order->get_order_currency() ) ) ) );
@@ -395,7 +395,7 @@ class WC_Gateway_Klarna_Order {
 		try {
 			$k_order->refund( array(
 				'refunded_amount' => $amount * 100,
-				'description'     => $reason,
+				'description'     => utf8_encode( $reason ),
 			) );
 			$order->add_order_note( sprintf( __( 'Klarna order refunded. Refund amount: %s.', 'woocommerce-gateway-klarna' ), wc_price( $amount, array( 'currency' => $order->get_order_currency() ) ) ) );
 

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -613,7 +613,17 @@ class WC_Gateway_Klarna_Order {
 			}
 		}
 		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
+			if ( 'gb' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_uk'];
+				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
+			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_dk'];
+				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
+			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_nl'];
+				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
+			}
+			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
 		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
@@ -723,7 +733,18 @@ class WC_Gateway_Klarna_Order {
 			}
 		}
 		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
+			if ( 'gb' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_uk'];
+				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
+			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_dk'];
+				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
+			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_nl'];
+				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
+			}
+
+			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
 		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
@@ -1054,7 +1075,18 @@ class WC_Gateway_Klarna_Order {
 			}
 		}
 		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
-			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
+			if ( 'gb' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_uk'];
+				$secret = html_entity_decode( $klarna_settings['secret_uk'] );
+			} elseif ( 'dk' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_dk'];
+				$secret = html_entity_decode( $klarna_settings['secret_dk'] );
+			} elseif ( 'nl' === strtolower( $billing_country ) ) {
+				$eid = $klarna_settings['eid_nl'];
+				$secret = html_entity_decode( $klarna_settings['secret_nl'] );
+			}
+
+			$connector = Klarna\Rest\Transport\Connector::create( $eid, $secret, $klarna_server_url );
 		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -483,7 +483,7 @@ class WC_Gateway_Klarna_Order {
 				break;
 			case 'NL' :
 				$klarna_country  = 'NL';
-				$klarna_language = 'nl-nl';
+				$klarna_language = 'nl-NL';
 				$klarna_currency = 'EUR';
 				$klarna_eid      = $klarna_settings['eid_nl'];
 				$klarna_secret   = $klarna_settings['secret_nl'];
@@ -600,21 +600,21 @@ class WC_Gateway_Klarna_Order {
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
-		} elseif ( 'us' == strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );
@@ -710,21 +710,21 @@ class WC_Gateway_Klarna_Order {
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
-		} elseif ( 'us' == strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );
@@ -1041,21 +1041,21 @@ class WC_Gateway_Klarna_Order {
 		 * Need to send local order to constructor and Klarna order to method
 		 */
 		if ( $klarna_settings['testmode'] == 'yes' ) {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 			}
 		} else {
-			if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+			if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' == strtolower( $billing_country ) ) {
+			} elseif ( 'us' === strtolower( $billing_country ) ) {
 				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 			}
 		}
-		if ( 'gb' == strtolower( $billing_country ) || 'dk' == strtolower( $billing_country ) ) {
+		if ( 'gb' === strtolower( $billing_country ) || 'dk' === strtolower( $billing_country ) || 'nl' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_uk'], html_entity_decode( $klarna_settings['secret_uk'] ), $klarna_server_url );
-		} elseif ( 'us' == strtolower( $billing_country ) ) {
+		} elseif ( 'us' === strtolower( $billing_country ) ) {
 			$connector = Klarna\Rest\Transport\Connector::create( $klarna_settings['eid_us'], html_entity_decode( $klarna_settings['secret_us'] ), $klarna_server_url );
 		}
 		$klarna_order_id = get_post_meta( $orderid, '_klarna_order_id', true );

--- a/classes/class-klarna-order.php
+++ b/classes/class-klarna-order.php
@@ -349,7 +349,7 @@ class WC_Gateway_Klarna_Order {
 			 * If yes, go ahead with good-will refund.
 			 */
 			if ( 1 == count( $order->get_taxes() ) ) {
-				$tax_rate = $order->get_cart_tax() / ( $order->get_total() - $order->get_cart_tax() ) * 100;
+				$tax_rate = (int) ($order->get_total_tax() / ( $order->get_total() - $order->get_total_tax() ) * 100);
 				try {
 					$ocr = $klarna->returnAmount( // returns 1 on success
 						$invNo,               // Invoice number

--- a/classes/class-klarna-shortcodes.php
+++ b/classes/class-klarna-shortcodes.php
@@ -125,6 +125,12 @@ class WC_Gateway_Klarna_Shortcodes {
 			if ( ! empty( $checkout_settings['eid_us'] ) ) {
 				$authorized_countries[] = 'US';
 			}
+			if ( ! empty( $checkout_settings['eid_dk'] ) ) {
+				$authorized_countries[] = 'DK';
+			}
+			if ( ! empty( $checkout_settings['eid_nl'] ) ) {
+				$authorized_countries[] = 'NL';
+			}
 
 			// Get array of Euro Klarna Checkout countries with Eid and secret defined
 			$klarna_checkout_countries = array();
@@ -136,6 +142,9 @@ class WC_Gateway_Klarna_Shortcodes {
 			}
 			if ( in_array( 'AT', $authorized_countries ) ) {
 				$klarna_checkout_countries['AT'] = __( 'Austria', 'woocommerce-gateway-klarna' );
+			}
+			if ( in_array( 'NL', $authorized_countries ) ) {
+				$klarna_checkout_countries['NL'] = __( 'Netherlands', 'woocommerce-gateway-klarna' );
 			}
 
 			/*
@@ -173,7 +182,7 @@ class WC_Gateway_Klarna_Shortcodes {
 			echo '<br />';
 			echo '<select id="klarna-checkout-euro-country" name="klarna-checkout-euro-country">';
 			foreach ( $klarna_checkout_enabled_countries as $klarna_checkout_enabled_country_code => $klarna_checkout_enabled_country ) {
-				echo '<option value="' . $klarna_checkout_enabled_country_code . '"' . selected( $klarna_checkout_enabled_country_code, $kco_euro_country, false ) . '>' . $klarna_checkout_enabled_country . '</option>';
+				echo '<option value="' . $klarna_checkout_enabled_country_code . '"' . selected( strtoupper( $klarna_checkout_enabled_country_code ), strtoupper( $kco_euro_country ), false ) . '>' . $klarna_checkout_enabled_country . '</option>';
 			}
 			echo '</select>';
 			echo '</label>';

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -89,6 +89,15 @@ class WC_Gateway_Klarna_K2WC {
 	 * @var    string, yes or no
 	 */
 	public $klarna_server;
+	
+	/**
+	 * Klarna credentials country.
+	 *
+	 * @since  2.3.3
+	 * @access public
+	 * @var    string
+	 */
+	public $klarna_credentials_country;
 
 	/**
 	 * Set is_rest value
@@ -168,6 +177,16 @@ class WC_Gateway_Klarna_K2WC {
 	 */
 	public function set_klarna_server( $klarna_server ) {
 		$this->klarna_server = $klarna_server;
+	}
+	
+	/**
+	 * Set klarna_credentials_country
+	 *
+	 * @since 2.3.3
+	 * @param string $klarna_credentials_country Used credentials country for purchase.
+	 */
+	public function set_klarna_credentials_country( $klarna_credentials_country ) {
+		$this->klarna_credentials_country = $klarna_credentials_country;
 	}
 
 	/**
@@ -267,7 +286,10 @@ class WC_Gateway_Klarna_K2WC {
 			} else {
 				update_post_meta( $order->id, '_klarna_api', 'v2' );
 			}
-
+			
+			// Store which KCO credentials country was used.
+			update_post_meta( $order->id, '_klarna_credentials_country', $this->klarna_credentials_country );
+			
 			return $order->id;
 		} else {
 			return false;

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -345,13 +345,13 @@ class WC_Gateway_Klarna_K2WC {
 			$klarna_country = sanitize_key( $_GET['scountry'] ); // Input var okay.
 
 			if ( 'yes' === $this->klarna_test_mode ) {
-				if ( 'gb' === $klarna_country || 'dk' === $klarna_country ) {
+				if ( 'gb' === $klarna_country || 'dk' === $klarna_country || 'nl' === $klarna_country ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 				} elseif ( 'us' === $klarna_country ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 				}
 			} else {
-				if ( 'gb' === $klarna_country || 'dk' === $klarna_country ) {
+				if ( 'gb' === $klarna_country || 'dk' === $klarna_country || 'nl' === $klarna_country ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
 				} elseif ( 'us' === $klarna_country ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -786,16 +786,14 @@ class WC_Gateway_Klarna_K2WC {
 		WC()->cart->calculate_fees();
 		WC()->cart->calculate_totals();
 
-		/*
-		$order->set_total( $woocommerce->cart->shipping_total, 'shipping' );
-		$order->set_total( $woocommerce->cart->get_cart_discount_total(), 'order_discount' );
-		$order->set_total( $woocommerce->cart->get_cart_discount_total(), 'cart_discount' );
-		$order->set_total( $woocommerce->cart->tax_total, 'tax' );
-		$order->set_total( $woocommerce->cart->shipping_tax_total, 'shipping_tax' );
-		$order->set_total( $woocommerce->cart->total );
-		*/
+		$order->set_total( WC()->cart->shipping_total, 'shipping' );
+		$order->set_total( WC()->cart->get_cart_discount_total(), 'cart_discount' );
+		$order->set_total( WC()->cart->get_cart_discount_tax_total(), 'cart_discount_tax' );
+		$order->set_total( WC()->cart->tax_total, 'tax' );
+		$order->set_total( WC()->cart->shipping_tax_total, 'shipping_tax' );
+		$order->set_total( WC()->cart->total );
 
-		$order->calculate_totals();
+		// $order->calculate_totals();
 	}
 
 	/**
@@ -900,8 +898,7 @@ class WC_Gateway_Klarna_K2WC {
 			$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 
 			if ( 'yes' === $checkout_settings['create_customer_account'] ) {
-				$password = wp_generate_password();
-				$customer_id = wc_create_new_customer( $klarna_order['billing_address']['email'], '', $password );
+				$customer_id = wc_create_new_customer( $klarna_order['billing_address']['email'] );
 				update_post_meta( $order->id, '_customer_user', $customer_id );
 				$order->add_order_note( sprintf( __( 'New customer created (user ID %s).', 'klarna' ), $customer_id, $klarna_order['id'] ) );
 			}

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -345,15 +345,15 @@ class WC_Gateway_Klarna_K2WC {
 			$klarna_country = sanitize_key( $_GET['scountry'] ); // Input var okay.
 
 			if ( 'yes' === $this->klarna_test_mode ) {
-				if ( 'gb' === $klarna_country || 'dk' === $klarna_country || 'nl' === $klarna_country ) {
+				if ( in_array( strtoupper( $klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ), sanitize_key($_GET['sid'] ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-				} elseif ( 'us' === $klarna_country ) {
+				} elseif ( in_array( strtoupper( $klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ), sanitize_key( $_GET['sid'] ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 				}
 			} else {
-				if ( 'gb' === $klarna_country || 'dk' === $klarna_country || 'nl' === $klarna_country ) {
+				if ( in_array( strtoupper( $klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ), sanitize_key($_GET['sid'] ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-				} elseif ( 'us' === $klarna_country ) {
+				} elseif ( in_array( strtoupper( $klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ), sanitize_key( $_GET['sid'] ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
 				}
 			}

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -881,11 +881,11 @@ class WC_Gateway_Klarna_K2WC {
 				$password = wp_generate_password();
 				$customer_id = wc_create_new_customer( $klarna_order['billing_address']['email'], '', $password );
 				update_post_meta( $order->id, '_customer_user', $customer_id );
+				$order->add_order_note( sprintf( __( 'New customer created (user ID %s).', 'klarna' ), $customer_id, $klarna_order['id'] ) );
 			}
 		}
 
 		if ( $customer_id > 0 ) {
-			$order->add_order_note( sprintf( __( 'New customer created (user ID %s).', 'klarna' ), $customer_id, $klarna_order['id'] ) );
 			if ( 'DE' === $_GET['scountry'] || 'AT' === $_GET['scountry'] ) { // Input var okay.
 				$received_billing_address_1  = $klarna_order['billing_address']['street_name'] . ' ' . $klarna_order['billing_address']['street_number'];
 				$received_shipping_address_1 = $klarna_order['shipping_address']['street_name'] . ' ' . $klarna_order['shipping_address']['street_number'];

--- a/classes/class-wc-to-klarna.php
+++ b/classes/class-wc-to-klarna.php
@@ -671,12 +671,12 @@ class WC_Gateway_Klarna_WC2K {
 		global $woocommerce;
 
 		if ( 'us' == $this->klarna_country ) {
-			$shipping_amount = (int) number_format( $woocommerce->cart->shipping_total * 100, 0, '', '' );
+			$shipping_amount = $woocommerce->cart->shipping_total;
 		} else {
-			$shipping_amount = (int) number_format( ( $woocommerce->cart->shipping_total + $woocommerce->cart->shipping_tax_total ) * 100, 0, '', '' );
+			$shipping_amount = $woocommerce->cart->shipping_total + $woocommerce->cart->shipping_tax_total;
 		}
 
-		return (int) $shipping_amount;
+		return round( $shipping_amount * 100 );
 	}
 
 	/**

--- a/classes/class-wc-to-klarna.php
+++ b/classes/class-wc-to-klarna.php
@@ -452,7 +452,7 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return integer $item_discount_amount Cart item discount.
 	 */
 	public function get_item_discount_amount( $cart_item ) {
-		if ( $cart_item['line_subtotal'] > $cart_item['line_total'] ) {
+		if ( round( $cart_item['line_subtotal'], 2 ) > round( $cart_item['line_total'], 2 ) ) {
 			$item_price           = $this->get_item_price( $cart_item );
 			$item_total_amount    = $this->get_item_total_amount( $cart_item );
 			$item_discount_amount = ( $item_price * $cart_item['quantity'] - $item_total_amount );

--- a/classes/class-wc-to-klarna.php
+++ b/classes/class-wc-to-klarna.php
@@ -64,8 +64,7 @@ class WC_Gateway_Klarna_WC2K {
 	 * @param string $klarna_country
 	 */
 	public function __construct( $is_rest = false, $klarna_country = '' ) {
-		global $woocommerce;
-		$this->cart           = $woocommerce->cart->get_cart();
+		$this->cart           = WC()->cart->get_cart();
 		$this->is_rest        = $is_rest;
 		$this->klarna_country = $klarna_country;
 	}
@@ -99,17 +98,15 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return array $cart_contents Formatted array ready for Klarna.
 	 */
 	public function process_cart_contents() {
-		global $woocommerce;
-
-		$woocommerce->cart->calculate_shipping();
-		$woocommerce->cart->calculate_totals();
+		WC()->cart->calculate_shipping();
+		WC()->cart->calculate_totals();
 
 		$cart = array();
 
 		// We need to keep track of order total, in case a smart coupon exceeds it
 		$order_total = 0;
 
-		foreach ( $woocommerce->cart->get_cart() as $cart_item ) {
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
 			if ( $cart_item['quantity'] ) {
 				if ( $cart_item['variation_id'] ) {
 					$_product = wc_get_product( $cart_item['variation_id'] );
@@ -155,8 +152,8 @@ class WC_Gateway_Klarna_WC2K {
 		}
 
 		// Process fees
-		if ( $woocommerce->cart->fee_total > 0 ) {
-			foreach ( $woocommerce->cart->get_fees() as $cart_fee ) {
+		if ( WC()->cart->fee_total > 0 ) {
+			foreach ( WC()->cart->get_fees() as $cart_fee ) {
 				$fee_name         = $this->get_fee_name( $cart_fee );
 				$fee_reference    = $this->get_fee_reference( $cart_fee );
 				$fee_type         = 'surcharge';
@@ -193,7 +190,7 @@ class WC_Gateway_Klarna_WC2K {
 		}
 
 		// Process shipping
-		if ( $woocommerce->shipping->get_packages() && $woocommerce->session->get( 'chosen_shipping_methods' ) ) {
+		if ( WC()->shipping->get_packages() && WC()->session->get( 'chosen_shipping_methods' ) ) {
 			$shipping_name       = $this->get_shipping_name();
 			$shipping_reference  = $this->get_shipping_reference();
 			$shipping_amount     = $this->get_shipping_amount();
@@ -233,7 +230,7 @@ class WC_Gateway_Klarna_WC2K {
 
 		// Process sales tax for US
 		if ( $this->is_rest && 'us' == $this->klarna_country ) {
-			$sales_tax = round( ( $woocommerce->cart->tax_total + $woocommerce->cart->shipping_tax_total ) * 100 );
+			$sales_tax = round( ( WC()->cart->tax_total + WC()->cart->shipping_tax_total ) * 100 );
 
 			// Add sales tax line item
 			$cart[] = array(
@@ -604,11 +601,9 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return string $shipping_name Name for selected shipping method.
 	 */
 	public function get_shipping_name() {
-		global $woocommerce;
-
-		$shipping_packages = $woocommerce->shipping->get_packages();
+		$shipping_packages = WC()->shipping->get_packages();
 		foreach ( $shipping_packages as $i => $package ) {
-			$chosen_method = isset( $woocommerce->session->chosen_shipping_methods[ $i ] ) ? $woocommerce->session->chosen_shipping_methods[ $i ] : '';
+			$chosen_method = isset( WC()->session->chosen_shipping_methods[ $i ] ) ? WC()->session->chosen_shipping_methods[ $i ] : '';
 
 			if ( '' != $chosen_method ) {
 				$package_rates = $package['rates'];
@@ -636,11 +631,9 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return string $shipping_reference Reference for selected shipping method.
 	 */
 	public function get_shipping_reference() {
-		global $woocommerce;
-
-		$shipping_packages = $woocommerce->shipping->get_packages();
+		$shipping_packages = WC()->shipping->get_packages();
 		foreach ( $shipping_packages as $i => $package ) {
-			$chosen_method = isset( $woocommerce->session->chosen_shipping_methods[ $i ] ) ? $woocommerce->session->chosen_shipping_methods[ $i ] : '';
+			$chosen_method = isset( WC()->session->chosen_shipping_methods[ $i ] ) ? WC()->session->chosen_shipping_methods[ $i ] : '';
 
 			if ( '' != $chosen_method ) {
 				$package_rates = $package['rates'];
@@ -668,12 +661,10 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return integer $shipping_amount Amount for selected shipping method.
 	 */
 	public function get_shipping_amount() {
-		global $woocommerce;
-
 		if ( 'us' == $this->klarna_country ) {
-			$shipping_amount = $woocommerce->cart->shipping_total;
+			$shipping_amount = WC()->cart->shipping_total;
 		} else {
-			$shipping_amount = $woocommerce->cart->shipping_total + $woocommerce->cart->shipping_tax_total;
+			$shipping_amount = WC()->cart->shipping_total + WC()->cart->shipping_tax_total;
 		}
 
 		return round( $shipping_amount * 100 );
@@ -688,15 +679,13 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return integer $shipping_tax_rate Tax rate for selected shipping method.
 	 */
 	public function get_shipping_tax_rate() {
-		global $woocommerce;
-
-		if ( $woocommerce->cart->shipping_tax_total > 0 && 'us' != $this->klarna_country ) {
-			$shipping_tax_rate = round( $woocommerce->cart->shipping_tax_total / $woocommerce->cart->shipping_total, 2 ) * 100;
+		if ( WC()->cart->shipping_tax_total > 0 && 'us' != $this->klarna_country ) {
+			$shipping_tax_rate = round( WC()->cart->shipping_tax_total / WC()->cart->shipping_total * 100 * 100 );
 		} else {
 			$shipping_tax_rate = 00;
 		}
 
-		return intval( $shipping_tax_rate . '00' );
+		return intval( $shipping_tax_rate );
 	}
 
 	/**
@@ -708,12 +697,10 @@ class WC_Gateway_Klarna_WC2K {
 	 * @return integer $shipping_tax_amount Tax amount for selected shipping method.
 	 */
 	public function get_shipping_tax_amount() {
-		global $woocommerce;
-
 		if ( 'us' == $this->klarna_country ) {
 			$shipping_tax_amount = 0;
 		} else {
-			$shipping_tax_amount = $woocommerce->cart->shipping_tax_total * 100;
+			$shipping_tax_amount = WC()->cart->shipping_tax_total * 100;
 		}
 
 		return (int) $shipping_tax_amount;

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -204,8 +204,8 @@ if ( wc_notice_count( 'error' ) > 0 ) {
 		}
 
 		// Setting these here because cross-sells need them
-		update_post_meta( $local_order_id, '_klarna_order_id', $klarna_order['order_id'], true );
-		update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ), true );
+		update_post_meta( $local_order_id, '_klarna_order_id', $sessionId );
+		update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ) );
 
 		// Set session values for Klarna order ID and Klarna order country
 		WC()->session->set( 'klarna_checkout', $sessionId );

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -32,199 +32,203 @@ if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_cont
 	}
 }
 
+// Let other plugins (like min/max) add their notices
+do_action('woocommerce_check_cart_items');
+if ( wc_notice_count( 'error' ) > 0 ) {
+	wp_safe_redirect( wc_get_cart_url() );
+} else {
+// Process order via Klarna Checkout page
+	if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+		define( 'WOOCOMMERCE_CHECKOUT', true );
+	}
 
 // Process order via Klarna Checkout page
-if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-	define( 'WOOCOMMERCE_CHECKOUT', true );
-}
-
-// Process order via Klarna Checkout page
-if ( ! defined( 'WOOCOMMERCE_KLARNA_CHECKOUT' ) ) {
-	define( 'WOOCOMMERCE_KLARNA_CHECKOUT', true );
-}
+	if ( ! defined( 'WOOCOMMERCE_KLARNA_CHECKOUT' ) ) {
+		define( 'WOOCOMMERCE_KLARNA_CHECKOUT', true );
+	}
 
 // Set Klarna Checkout as the chosen payment method in the WC session
-WC()->session->set( 'chosen_payment_method', 'klarna_checkout' );
+	WC()->session->set( 'chosen_payment_method', 'klarna_checkout' );
 
 // Set customer country so taxes and shipping can be calculated properly
-WC()->customer->set_country( strtoupper( $this->get_klarna_country() ) );
-WC()->customer->set_shipping_country( strtoupper( $this->get_klarna_country() ) );
+	WC()->customer->set_country( strtoupper( $this->get_klarna_country() ) );
+	WC()->customer->set_shipping_country( strtoupper( $this->get_klarna_country() ) );
 
 // Debug
-if ( $this->debug == 'yes' ) {
-	$this->log->add( 'klarna', 'Rendering Checkout page...' );
-}
+	if ( $this->debug == 'yes' ) {
+		$this->log->add( 'klarna', 'Rendering Checkout page...' );
+	}
 
 // Mobile or desktop browser
-if ( wp_is_mobile() ) {
-	$klarna_checkout_layout = 'mobile';
-} else {
-	$klarna_checkout_layout = 'desktop';
-}
-
-/**
- * Set $add_klarna_window_size_script to true so that Window size
- * detection script can load in the footer
- */
-global $add_klarna_window_size_script;
-$add_klarna_window_size_script = true;
-
-// Recheck cart items so that they are in stock
-$result = $woocommerce->cart->check_cart_item_stock();
-if ( is_wp_error( $result ) ) {
-	return $result->get_error_message();
-}
-
-// Check if there's anything in the cart
-if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
-
-	if ( isset( $_GET['no_shipping'] ) ) {
-		echo '<div class="woocommerce-error">';
-		_e( 'Please select a shipping method', 'woocommerce-gateway-klarna' );
-		echo '</div>';
-	}
-
-	// Add button to Standard Checkout Page if this is enabled in the settings
-	if ( $this->add_std_checkout_button == 'yes' ) {
-		echo '<div class="woocommerce">';
-		echo '<a href="' . get_permalink( get_option( 'woocommerce_checkout_page_id' ) ) . '" class="button std-checkout-button">';
-		echo $this->std_checkout_button_label;
-		echo '</a>';
-		echo  '</div>';
-	}
-
-	// Get Klarna credentials
-	$eid          = $this->klarna_eid;
-	$sharedSecret = $this->klarna_secret;
-
-	// Process cart contents and prepare them for Klarna
-	include_once( KLARNA_DIR . 'classes/class-wc-to-klarna.php' );
-	$wc_to_klarna = new WC_Gateway_Klarna_WC2K( $this->is_rest(), $this->klarna_country );
-	$cart         = $wc_to_klarna->process_cart_contents();
-
-	// Initiate Klarna
-	if ( $this->is_rest() ) {
-		if ( $this->testmode == 'yes' ) {
-			if ( 'gb' == $this->klarna_country || 'dk' == $this->klarna_country ) {
-				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
-			} elseif ( 'us' == $this->klarna_country ) {
-				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
-			}
-		} else {
-			if ( 'gb' == $this->klarna_country || 'dk' == $this->klarna_country ) {
-				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
-			} elseif ( 'us' == $this->klarna_country ) {
-				$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
-			}
-		}
-		$connector = Klarna\Rest\Transport\Connector::create( $eid, $sharedSecret, $klarna_server_url );
+	if ( wp_is_mobile() ) {
+		$klarna_checkout_layout = 'mobile';
 	} else {
-		$connector = Klarna_Checkout_Connector::create( $sharedSecret, $this->klarna_server );
+		$klarna_checkout_layout = 'desktop';
 	}
-	$klarna_order = null;
-
 
 	/**
-	 * Create WooCommerce order
+	 * Set $add_klarna_window_size_script to true so that Window size
+	 * detection script can load in the footer
 	 */
-	$orderid = $this->update_or_create_local_order();
+	global $add_klarna_window_size_script;
+	$add_klarna_window_size_script = true;
 
-	// Add GA cookie as custom field for GA Ecommerce plugin.
-	if ( class_exists( 'Yoast_GA_Woo_eCommerce_Tracking' ) && isset( $_COOKIE['_ga'] ) ) {
-		// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
-		// so strip the version number.
-		$cookie = preg_replace( '/^(GA\d\.\d\.)/', '', $_COOKIE['_ga'] );
-		update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
+// Recheck cart items so that they are in stock
+	$result = $woocommerce->cart->check_cart_item_stock();
+	if ( is_wp_error( $result ) ) {
+		return $result->get_error_message();
 	}
 
-	// Add GA cookie as custom field for GA Ecommerce plugin.
-	if ( class_exists( 'MonsterInsights_eCommerce' ) && isset( $_COOKIE['_ga'] ) ) {
-		// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
-		// so strip the version number.
-		$cookie       = '';
-		$ga_cookie    = $_COOKIE['_ga'];
-		$cookie_parts = explode( '.', $ga_cookie );
-		if ( is_array( $cookie_parts ) && ! empty( $cookie_parts[2] ) && ! empty( $cookie_parts[3] ) ) {
-			$uuid = (string) $cookie_parts[2] . '.' . (string) $cookie_parts[3];
-			if ( is_string( $uuid ) ) {
-				$cookie = $uuid;
-			} else {
-				$cookie = false;
-			}
-		} else {
-			$cookie = false;
-		}
-		update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
+// Check if there's anything in the cart
+	if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 
-		$cookie = '';
-		if ( empty( $_COOKIE['_ga'] ) ) {
-			$cookie = 'FCE';
+		if ( isset( $_GET['no_shipping'] ) ) {
+			echo '<div class="woocommerce-error">';
+			_e( 'Please select a shipping method', 'woocommerce-gateway-klarna' );
+			echo '</div>';
+		}
+
+		// Add button to Standard Checkout Page if this is enabled in the settings
+		if ( $this->add_std_checkout_button == 'yes' ) {
+			echo '<div class="woocommerce">';
+			echo '<a href="' . get_permalink( get_option( 'woocommerce_checkout_page_id' ) ) . '" class="button std-checkout-button">';
+			echo $this->std_checkout_button_label;
+			echo '</a>';
+			echo '</div>';
+		}
+
+		// Get Klarna credentials
+		$eid          = $this->klarna_eid;
+		$sharedSecret = $this->klarna_secret;
+
+		// Process cart contents and prepare them for Klarna
+		include_once( KLARNA_DIR . 'classes/class-wc-to-klarna.php' );
+		$wc_to_klarna = new WC_Gateway_Klarna_WC2K( $this->is_rest(), $this->klarna_country );
+		$cart         = $wc_to_klarna->process_cart_contents();
+
+		// Initiate Klarna
+		if ( $this->is_rest() ) {
+			if ( $this->testmode == 'yes' ) {
+				if ( 'gb' == $this->klarna_country || 'dk' == $this->klarna_country ) {
+					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
+				} elseif ( 'us' == $this->klarna_country ) {
+					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
+				}
+			} else {
+				if ( 'gb' == $this->klarna_country || 'dk' == $this->klarna_country ) {
+					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
+				} elseif ( 'us' == $this->klarna_country ) {
+					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;
+				}
+			}
+			$connector = Klarna\Rest\Transport\Connector::create( $eid, $sharedSecret, $klarna_server_url );
 		} else {
+			$connector = Klarna_Checkout_Connector::create( $sharedSecret, $this->klarna_server );
+		}
+		$klarna_order = null;
+
+
+		/**
+		 * Create WooCommerce order
+		 */
+		$orderid = $this->update_or_create_local_order();
+
+		// Add GA cookie as custom field for GA Ecommerce plugin.
+		if ( class_exists( 'Yoast_GA_Woo_eCommerce_Tracking' ) && isset( $_COOKIE['_ga'] ) ) {
+			// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
+			// so strip the version number.
+			$cookie = preg_replace( '/^(GA\d\.\d\.)/', '', $_COOKIE['_ga'] );
+			update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
+		}
+
+		// Add GA cookie as custom field for GA Ecommerce plugin.
+		if ( class_exists( 'MonsterInsights_eCommerce' ) && isset( $_COOKIE['_ga'] ) ) {
+			// The _ga cookie consists of GA[version_number][user_id], we are only interested in the user_id
+			// so strip the version number.
+			$cookie       = '';
 			$ga_cookie    = $_COOKIE['_ga'];
 			$cookie_parts = explode( '.', $ga_cookie );
 			if ( is_array( $cookie_parts ) && ! empty( $cookie_parts[2] ) && ! empty( $cookie_parts[3] ) ) {
 				$uuid = (string) $cookie_parts[2] . '.' . (string) $cookie_parts[3];
 				if ( is_string( $uuid ) ) {
-					$cookie = $ga_cookie;
+					$cookie = $uuid;
 				} else {
-					$cookie = 'FA';
+					$cookie = false;
 				}
 			} else {
-				$cookie = 'FAE';
+				$cookie = false;
 			}
+			update_post_meta( $orderid, '_yoast_gau_uuid', $cookie );
+
+			$cookie = '';
+			if ( empty( $_COOKIE['_ga'] ) ) {
+				$cookie = 'FCE';
+			} else {
+				$ga_cookie    = $_COOKIE['_ga'];
+				$cookie_parts = explode( '.', $ga_cookie );
+				if ( is_array( $cookie_parts ) && ! empty( $cookie_parts[2] ) && ! empty( $cookie_parts[3] ) ) {
+					$uuid = (string) $cookie_parts[2] . '.' . (string) $cookie_parts[3];
+					if ( is_string( $uuid ) ) {
+						$cookie = $ga_cookie;
+					} else {
+						$cookie = 'FA';
+					}
+				} else {
+					$cookie = 'FAE';
+				}
+			}
+			update_post_meta( $orderid, '_monsterinsights_cookie', $cookie );
 		}
-		update_post_meta( $orderid, '_monsterinsights_cookie', $cookie );
-	}
 
 
+		// WC Subscriptions 2.0 needs this
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			update_post_meta( $orderid, '_klarna_recurring_carts', WC()->cart->recurring_carts );
+		}
 
-	// WC Subscriptions 2.0 needs this
-	if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
-		update_post_meta( $orderid, '_klarna_recurring_carts',  WC()->cart->recurring_carts );
-	}
+		/**
+		 * Check if Klarna order already exists and if country was changed
+		 */
+		if ( WC()->session->get( 'klarna_checkout' ) && WC()->session->get( 'klarna_checkout_country' ) == WC()->customer->get_country() ) {
+			include( KLARNA_DIR . 'includes/checkout/resume.php' );
+		}
+		// If it doesn't, create Klarna order
+		if ( $klarna_order == null ) {
+			include( KLARNA_DIR . 'includes/checkout/create.php' );
+		}
 
-	/**
-	 * Check if Klarna order already exists and if country was changed
-	 */
-	if ( WC()->session->get( 'klarna_checkout' ) && WC()->session->get( 'klarna_checkout_country' ) == WC()->customer->get_country() ) {
-		include( KLARNA_DIR . 'includes/checkout/resume.php' );
-	}
-	// If it doesn't, create Klarna order
-	if ( $klarna_order == null ) {
-		include( KLARNA_DIR . 'includes/checkout/create.php' );
-	}
+		// Store location of checkout session
+		if ( $this->is_rest() ) {
+			$sessionId = $klarna_order['order_id'];
+		} else {
+			$sessionId = $klarna_order['id'];
+		}
 
-	// Store location of checkout session
-	if ( $this->is_rest() ) {
-		$sessionId = $klarna_order['order_id'];
+		// Setting these here because cross-sells need them
+		update_post_meta( $local_order_id, '_klarna_order_id', $klarna_order['order_id'], true );
+		update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ), true );
+
+		// Set session values for Klarna order ID and Klarna order country
+		WC()->session->set( 'klarna_checkout', $sessionId );
+		WC()->session->set( 'klarna_checkout_country', WC()->customer->get_country() );
+
+		// Display checkout
+		do_action( 'klarna_before_kco_checkout' );
+		if ( $this->is_rest() ) {
+			$snippet = $klarna_order['html_snippet'];
+		} else {
+			$snippet = $klarna_order['gui']['snippet'];
+		}
+		echo '<div>' . apply_filters( 'klarna_kco_checkout', $snippet ) . '</div>';
+
+		do_action( 'klarna_after_kco_checkout' );
 	} else {
-		$sessionId = $klarna_order['id'];
-	}
-
-	// Setting these here because cross-sells need them
-	update_post_meta( $local_order_id, '_klarna_order_id', $klarna_order['order_id'], true );
-	update_post_meta( $local_order_id, '_billing_country', WC()->session->get( 'klarna_country' ), true );
-
-	// Set session values for Klarna order ID and Klarna order country
-	WC()->session->set( 'klarna_checkout', $sessionId );
-	WC()->session->set( 'klarna_checkout_country', WC()->customer->get_country() );
-
-	// Display checkout
-	do_action( 'klarna_before_kco_checkout' );
-	if ( $this->is_rest() ) {
-		$snippet = $klarna_order['html_snippet'];
-	} else {
-		$snippet = $klarna_order['gui']['snippet'];
-	}
-	echo '<div>' . apply_filters( 'klarna_kco_checkout', $snippet ) . '</div>';
-
-	do_action( 'klarna_after_kco_checkout' );
-} else {
-	// If cart is empty, clear these variables
-	wp_delete_post( WC()->session->get( 'ongoing_klarna_order' ), true ); // Delete WooCommerce order
-	WC()->session->__unset( 'klarna_checkout' ); // Klarna order ID
-	WC()->session->__unset( 'klarna_checkout_country' ); // Klarna order ID
-	WC()->session->__unset( 'ongoing_klarna_order' ); // WooCommerce order ID
-	WC()->session->__unset( 'klarna_order_note' ); // Order note
-	wp_redirect( $woocommerce->cart->get_cart_url() ); // Redirect to cart page
-} // End if sizeof cart
+		// If cart is empty, clear these variables
+		wp_delete_post( WC()->session->get( 'ongoing_klarna_order' ), true ); // Delete WooCommerce order
+		WC()->session->__unset( 'klarna_checkout' ); // Klarna order ID
+		WC()->session->__unset( 'klarna_checkout_country' ); // Klarna order ID
+		WC()->session->__unset( 'ongoing_klarna_order' ); // WooCommerce order ID
+		WC()->session->__unset( 'klarna_order_note' ); // Order note
+		wp_redirect( $woocommerce->cart->get_cart_url() ); // Redirect to cart page
+	} // End if sizeof cart
+}

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -108,13 +108,13 @@ if ( wc_notice_count( 'error' ) > 0 ) {
 		// Initiate Klarna.
 		if ( $this->is_rest() ) {
 			if ( 'yes' === $this->testmode ) {
-				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 				} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 				}
 			} else {
-				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+				if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
 				} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 					$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;

--- a/includes/checkout/create.php
+++ b/includes/checkout/create.php
@@ -18,13 +18,19 @@ $local_order_id      = WC()->session->get( 'ongoing_klarna_order' );
 $kco_session_locale  = '';
 
 if ( ( 'en_US' == get_locale() || 'en_GB' == get_locale() ) && 'DE' != $kco_session_country ) {
-	if ( 'en_US' == get_locale() ) {
-		$kco_session_locale = 'en-US';
+	if ( 'nl' === $kco_session_country ) {
+		$kco_session_locale = 'en-nl';
 	} else {
-		$kco_session_locale = 'en-gb';
+		if ( 'en_US' == get_locale() ) {
+			$kco_session_locale = 'en-US';
+		} else {
+			$kco_session_locale = 'en-gb';
+		}
 	}
 } elseif ( '' != $kco_session_country ) {
-	if ( 'DE' == $kco_session_country ) {
+	if ( 'nl' === $kco_session_country ) {
+		$kco_session_locale = 'nl-nl';
+	} elseif ( 'DE' == $kco_session_country ) {
 		$kco_session_locale = 'de-de';
 	} elseif ( 'AT' == $kco_session_country ) {
 		$kco_session_locale = 'de-at';
@@ -265,6 +271,8 @@ if ( $this->is_rest() ) {
 	$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 	if ( 'gb' == $this->klarna_country && 'yes' == $checkout_settings['uk_ship_only_to_base'] ) {
 		$create['shipping_countries'] = array();
+	} elseif ( 'nl' == $this->klarna_country ) {
+		$create['shipping_countries'] = array( 'NL' );
 	} else {
 		// Add shipping countries
 		$wc_countries                 = new WC_Countries();

--- a/includes/checkout/resume.php
+++ b/includes/checkout/resume.php
@@ -70,13 +70,19 @@ try {
 
 		$kco_session_locale  = '';
 		if ( ( 'en_US' === get_locale() || 'en_GB' === get_locale() ) && 'DE' !== $kco_session_country ) {
-			if ( 'en_US' === get_locale() ) {
-				$kco_session_locale = 'en-US';
+			if ( 'nl' === $kco_session_country ) {
+				$kco_session_locale = 'en-nl';
 			} else {
-				$kco_session_locale = 'en-gb';
+				if ( 'en_US' === get_locale() ) {
+					$kco_session_locale = 'en-US';
+				} else {
+					$kco_session_locale = 'en-gb';
+				}
 			}
 		} elseif ( '' !== $kco_session_country ) {
-			if ( 'DE' === $kco_session_country ) {
+			if ( 'nl' === $kco_session_country ) {
+				$kco_session_locale = 'nl-nl';
+			} elseif ( 'DE' === $kco_session_country ) {
 				$kco_session_locale = 'de-de';
 			} elseif ( 'AT' === $kco_session_country ) {
 				$kco_session_locale = 'de-at';
@@ -206,6 +212,8 @@ try {
 			$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 			if ( 'gb' === $this->klarna_country && 'yes' === $checkout_settings['uk_ship_only_to_base'] ) {
 				$update['shipping_countries'] = array();
+			} elseif ( 'nl' == $this->klarna_country ) {
+				$update['shipping_countries'] = array( 'NL' );
 			} else {
 				$wc_countries                 = new WC_Countries();
 				$update['shipping_countries'] = array_keys( $wc_countries->get_shipping_countries() );

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -95,15 +95,14 @@ if ( $order->get_user_id() === 0 ) {
 		// Create new user.
 		$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 		if ( 'yes' === $checkout_settings['create_customer_account'] ) {
-			$password = wp_generate_password();
-			$customer_id = wc_create_new_customer( $klarna_order['billing_address']['email'], '', $password );
+			$customer_id = wc_create_new_customer( $klarna_order['billing_address']['email'] );
 			update_post_meta( $order_id, '_customer_user', $customer_id );
 		}
 	}
 }
 
 // Log the user in.
-if ( $order->get_user_id() > 0 ) {
+if ( ! is_user_logged_in() && $order->get_user_id() > 0 ) {
 	wp_set_current_user( $order->get_user_id() );
 	wc_set_customer_auth_cookie( $order->get_user_id() );
 }

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -33,13 +33,13 @@ $order        = wc_get_order( $order_id );
 // Connect to Klarna
 if ( $this->is_rest() ) {
 	if ( $this->testmode == 'yes' ) {
-		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 			$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 		} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 			$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_TEST_BASE_URL;
 		}
 	} else {
-		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB' ) ) ) ) {
+		if ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_eu', array( 'DK', 'GB', 'NL' ) ) ) ) {
 			$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::EU_BASE_URL;
 		} elseif ( in_array( strtoupper( $this->klarna_country ), apply_filters( 'klarna_is_rest_countries_na', array( 'US' ) ) ) ) {
 			$klarna_server_url = Klarna\Rest\Transport\ConnectorInterface::NA_BASE_URL;

--- a/includes/settings-checkout.php
+++ b/includes/settings-checkout.php
@@ -192,6 +192,39 @@ return apply_filters( 'klarna_checkout_form_fields', array(
 		'desc_tip'    => false
 	),
 
+	'nl_settings_title'             => array(
+		'title' => __( 'Netherlands', 'woocommerce-gateway-klarna' ),
+		'type'  => 'title',
+	),
+	'eid_nl'                        => array(
+		'title'       => __( 'Eid - Netherlands', 'woocommerce-gateway-klarna' ),
+		'type'        => 'text',
+		'description' => __( 'Please enter your Klarna Eid for Netherlands. Leave blank to disable.', 'woocommerce-gateway-klarna' ),
+		'default'     => '',
+		'desc_tip'    => true
+	),
+	'secret_nl'                     => array(
+		'title'       => __( 'Shared Secret - Netherlands', 'woocommerce-gateway-klarna' ),
+		'type'        => 'text',
+		'description' => __( 'Please enter your Klarna Shared Secret for Netherlands.', 'woocommerce-gateway-klarna' ),
+		'default'     => '',
+		'desc_tip'    => true
+	),
+	'klarna_checkout_url_nl'        => array(
+		'title'       => __( 'Custom Checkout Page - Netherlands', 'woocommerce-gateway-klarna' ),
+		'type'        => 'text',
+		'description' => __( 'Please enter the URL to the page that acts as Checkout Page for Klarna Checkout Netherlands. This page must contain the shortcode [woocommerce_klarna_checkout].', 'woocommerce-gateway-klarna' ),
+		'default'     => '',
+		'desc_tip'    => false
+	),
+	'klarna_checkout_thanks_url_nl' => array(
+		'title'       => __( 'Custom Thanks Page - Netherlands', 'woocommerce-gateway-klarna' ),
+		'type'        => 'text',
+		'description' => __( 'Enter the URL to the page that acts as Thanks Page for Klarna Checkout Netherlands. This page must contain the shortcode [woocommerce_klarna_checkout]. Leave blank to use the Custom Checkout Page as Thanks Page.', 'woocommerce-gateway-klarna' ),
+		'default'     => '',
+		'desc_tip'    => false
+	),
+
 	'germany_settings_title'        => array(
 		'title' => __( 'Germany', 'woocommerce-gateway-klarna' ),
 		'type'  => 'title',
@@ -361,7 +394,8 @@ return apply_filters( 'klarna_checkout_form_fields', array(
 		'options'     => array(
 			'DE' => __( 'Germany', 'woocommerce-gateway-klarna' ),
 			'FI' => __( 'Finland', 'woocommerce-gateway-klarna' ),
-			'AT' => __( 'Austria', 'woocommerce-gateway-klarna' )
+			'AT' => __( 'Austria', 'woocommerce-gateway-klarna' ),
+			'NL' => __( 'Netherlands', 'woocommerce-gateway-klarna' )
 		),
 		'description' => __( 'Used by the payment gateway to determine which country should be the default Checkout country if Euro is the selected currency, you as a merchant has an agreement with multiple countries that use Euro and the selected language cant be of help for this decision.', 'woocommerce-gateway-klarna' ),
 		'default'     => 'DE',

--- a/includes/variables-checkout.php
+++ b/includes/variables-checkout.php
@@ -37,6 +37,11 @@ $this->secret_dk                     = ( isset( $this->settings['secret_dk'] ) )
 $this->klarna_checkout_url_dk        = ( isset( $this->settings['klarna_checkout_url_dk'] ) ) ? $this->settings['klarna_checkout_url_dk'] : '';
 $this->klarna_checkout_thanks_url_dk = ( isset( $this->settings['klarna_checkout_thanks_url_dk'] ) ) ? $this->settings['klarna_checkout_thanks_url_dk'] : '';
 
+$this->eid_nl                        = ( isset( $this->settings['eid_nl'] ) ) ? $this->settings['eid_nl'] : '';
+$this->secret_nl                     = ( isset( $this->settings['secret_nl'] ) ) ? html_entity_decode( $this->settings['secret_nl'] ) : '';
+$this->klarna_checkout_url_nl        = ( isset( $this->settings['klarna_checkout_url_nl'] ) ) ? $this->settings['klarna_checkout_url_nl'] : '';
+$this->klarna_checkout_thanks_url_nl = ( isset( $this->settings['klarna_checkout_thanks_url_nl'] ) ) ? $this->settings['klarna_checkout_thanks_url_nl'] : '';
+
 $this->eid_de                        = ( isset( $this->settings['eid_de'] ) ) ? $this->settings['eid_de'] : '';
 $this->secret_de                     = ( isset( $this->settings['secret_de'] ) ) ? $this->settings['secret_de'] : '';
 $this->klarna_checkout_url_de        = ( isset( $this->settings['klarna_checkout_url_de'] ) ) ? $this->settings['klarna_checkout_url_de'] : '';
@@ -117,8 +122,8 @@ endif;
 
 // We need to check if WPML is active
 if(!is_admin()) {
-	if( $woocommerce->session->get('client_currency') ) {
-		$customer_selected_currency = $woocommerce->session->get('client_currency');
+	if( WC()->session->get('client_currency') ) {
+		$customer_selected_currency = WC()->session->get('client_currency');
 	} else {
 		$customer_selected_currency = get_woocommerce_currency();
 	}
@@ -140,6 +145,8 @@ switch ( $customer_selected_currency ) {
 				$klarna_country = 'FI';
 			} elseif ( get_locale() == 'de_AT' && '' != $this->eid_at && '' != $this->secret_at ) {
 				$klarna_country = 'AT';
+			}  elseif ( get_locale() == 'nl_NL' && '' != $this->eid_nl && '' != $this->secret_nl ) {
+				$klarna_country = 'NL';
 			} else {
 				$klarna_country = $this->default_eur_contry;
 			}
@@ -229,6 +236,20 @@ switch ( $this->shop_country ) {
 			$klarna_checkout_thanks_url = $this->klarna_checkout_thanks_url_dk;
 		}
 		break;
+	case 'nl' :
+	case 'NL' :
+		$klarna_country = 'nl';
+
+		$klarna_language     = 'nl-NL';
+		$klarna_eid          = $this->eid_nl;
+		$klarna_secret       = $this->secret_nl;
+		$klarna_checkout_url = $this->klarna_checkout_url_nl;
+		if ( $this->klarna_checkout_thanks_url_nl == '' ) {
+			$klarna_checkout_thanks_url = $this->klarna_checkout_url_nl;
+		} else {
+			$klarna_checkout_thanks_url = $this->klarna_checkout_thanks_url_nl;
+		}
+		break;
 	case 'DE' :
 		$klarna_country      = 'DE';
 		$klarna_language     = 'de-de';
@@ -302,6 +323,9 @@ if ( ! empty( $this->eid_fi ) ) {
 }
 if ( ! empty( $this->eid_dk ) ) {
 	$this->authorized_countries[] = 'DK';
+}
+if ( ! empty( $this->eid_nl ) ) {
+	$this->authorized_countries[] = 'NL';
 }
 if ( ! empty( $this->eid_de ) ) {
 	$this->authorized_countries[] = 'DE';

--- a/includes/variables-checkout.php
+++ b/includes/variables-checkout.php
@@ -348,6 +348,7 @@ if ( ! is_admin() && ! empty( $klarna_country ) ) {
 
 // Apply filters to Country and language
 $this->klarna_country             = apply_filters( 'klarna_country', $klarna_country );
+$this->klarna_credentials_country = apply_filters( 'klarna_credentials_country', $klarna_country );
 $this->klarna_language            = apply_filters( 'klarna_language', $klarna_language );
 $this->klarna_eid                 = apply_filters( 'klarna_eid', $klarna_eid );
 $this->klarna_secret              = apply_filters( 'klarna_secret', $klarna_secret );

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.3
+ * Version:         2.3.1
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( !defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.3' );
+	define( 'WC_KLARNA_VER', '2.3.1' );
 }
 
 /**

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.3.1
+ * Version:         2.3.2
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -27,8 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( !defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.3.1' );
+if ( ! defined( 'WC_KLARNA_VER' ) ) {
+	define( 'WC_KLARNA_VER', '2.3.2' );
 }
 
 /**


### PR DESCRIPTION
* Fix       - Fixed compatibility with WooCommerce Min/Max plugin.
* Fix       - Fixed compatibility with Subscriptions/Memberships combination of plugins.
* Fix       - Adds support for KCO NL.
* Fix       - Fixes tax rate calculation in refunds for KCO V2.
* Fix       - Fixes order total calculation when shipping doesn't have tax for KCO.
* Fix       - Fixes WooCommerce order total calculation when coupons are used in KCO V3.
* Fix       - Adds utf8_encode to refund reason.
* Update    - Adds klarna_is_rest_countries_eu and klarna_is_rest_countries_na filters.
* Update    - Stores Klarna credentials country as order meta field.