### PR TITLE
2.3.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.04.06  - version 2.3.5
+* Hotfix    - Fixes undeclared global variable from previous version, in get_checkout_page() method.
+
 2017.04.05  - version 2.3.4
 * Fix       - Removes deprecated functions (woocommerce_clean, WC()->cart->get_cart_url(), WC()->cart->get_checkout_url(), woocommerce_get_page_id, get_product)
 * Fix       - Fixes error handling error in WC_Gateway_Klarna_K2WC class.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -1456,6 +1456,9 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 * @since 1.0.0
 	 */
 	function get_klarna_checkout_page() {
+		global $woocommerce;
+ 		$current_user = wp_get_current_user();
+
 		// Debug
 		if ( $this->debug == 'yes' ) {
 			$this->log->add( 'klarna', 'KCO page about to render...' );

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.3.4
+ * Version:         2.3.5
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.3.4' );
+	define( 'WC_KLARNA_VER', '2.3.5' );
 }
 
 /**


### PR DESCRIPTION
* Hotfix    - Fixes undeclared global variable from previous version, in get_checkout_page() method.
