### PR TITLE
2.3.12

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.07.07  - version 2.3.12
+* Update	- Adds setting for Allow separate shipping address (KCO V2).
+* Fix		- Fixes WooCommerce Subscriptions issue - adds customer address to order before woocommerce_checkout_order_processed hook is run.
+* Fix		- Fixes WooCommerce Subscriptions issue - adds check to activate subscription if parent order already has been set to processing/completed when subscription is created.
+
 2017.06.13  - version 2.3.11
 * Fix       - Fixes missing SKU in Klarna Invoice.
 * Fix       - Fixes accessing customer country property directly in WC 3.0.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update	- Adds setting for Allow separate shipping address (KCO V2).
 * Fix		- Fixes WooCommerce Subscriptions issue - adds customer address to order before woocommerce_checkout_order_processed hook is run.
 * Fix		- Fixes WooCommerce Subscriptions issue - adds check to activate subscription if parent order already has been set to processing/completed when subscription is created.
+* Fix		- Fixes invoice fee (no product) issue.
 
 2017.06.13  - version 2.3.11
 * Fix       - Fixes missing SKU in Klarna Invoice.

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -231,37 +231,44 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 	 */
 	function finalize_subscription( $subscription, $order, $cart ) {
 		$subscription_shipping_methods = $subscription->get_shipping_methods();
-		if ( $this->id === $subscription->payment_method && empty( $subscription_shipping_methods ) ) {
-			WC_Subscriptions_Cart::set_calculation_type( 'recurring_total' );
-
-			foreach ( $cart->get_shipping_packages() as $base_package ) {
-
-				$package = WC()->shipping->calculate_shipping_for_package( $base_package );
-
-				foreach ( WC()->shipping->get_packages() as $package_key => $package_to_ignore ) {
-
-					$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
-					if ( isset( $package['rates'][ $chosen_shipping_methods[ $package_key ] ] ) ) {
-
-						$item_id = $subscription->add_shipping( $package['rates'][ $chosen_shipping_methods[ $package_key ] ] );
-
-						if ( ! $item_id ) {
-							throw new Exception( __( 'Error: Unable to create subscription. Please try again.', 'woocommerce-subscriptions' ) );
+		if ( $this->id === $subscription->payment_method ) {
+			if ( empty( $subscription_shipping_methods ) ) {
+				WC_Subscriptions_Cart::set_calculation_type( 'recurring_total' );
+	
+				foreach ( $cart->get_shipping_packages() as $base_package ) {
+	
+					$package = WC()->shipping->calculate_shipping_for_package( $base_package );
+	
+					foreach ( WC()->shipping->get_packages() as $package_key => $package_to_ignore ) {
+	
+						$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+						if ( isset( $package['rates'][ $chosen_shipping_methods[ $package_key ] ] ) ) {
+	
+							$item_id = $subscription->add_shipping( $package['rates'][ $chosen_shipping_methods[ $package_key ] ] );
+	
+							if ( ! $item_id ) {
+								throw new Exception( __( 'Error: Unable to create subscription. Please try again.', 'woocommerce-subscriptions' ) );
+							}
+	
+							// Allows plugins to add order item meta to shipping.
+							do_action( 'woocommerce_add_shipping_order_item', $subscription->id, $item_id, $package_key );
+							do_action( 'woocommerce_subscriptions_add_recurring_shipping_order_item', $subscription->id, $item_id, $package_key );
 						}
-
-						// Allows plugins to add order item meta to shipping.
-						do_action( 'woocommerce_add_shipping_order_item', $subscription->id, $item_id, $package_key );
-						do_action( 'woocommerce_subscriptions_add_recurring_shipping_order_item', $subscription->id, $item_id, $package_key );
 					}
 				}
+	
+				WC_Subscriptions_Cart::set_calculation_type( 'none' );
+	
+				$subscription->calculate_shipping();
+				$subscription->calculate_totals( true );
+				$subscription->payment_complete();
 			}
-
-			WC_Subscriptions_Cart::set_calculation_type( 'none' );
-
-			$subscription->calculate_shipping();
-			$subscription->calculate_totals( true );
-
-			$subscription->payment_complete();
+			
+			// In some cases the parent order is set to Processing/Completed (on a callback from Klarna) before the subscription is created.
+			// In these cases we ned to activate the subscription ourselves.
+			if ( $order->has_status( array( 'processing', 'completed' ) ) ) {
+				$subscription->update_status( 'active' );
+			}
 		}
 	}
 

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -334,7 +334,7 @@ class WC_Gateway_Klarna_K2WC {
 			$this->change_order_currency( $order, $klarna_order );
 
 			// Add order addresses.
-			$this->add_order_addresses( $order, $klarna_order );
+			self::add_order_addresses( $order, $klarna_order );
 
 			// Store payment method.
 			$this->add_order_payment_method( $order );
@@ -631,13 +631,9 @@ class WC_Gateway_Klarna_K2WC {
 	 * @param  object $order Local WC order.
 	 * @param  object $klarna_order Klarna order.
 	 */
-	public function add_order_addresses( $order, $klarna_order ) {
+	public static function add_order_addresses( $order, $klarna_order ) {
 		$order_id = klarna_wc_get_order_id( $order );
 
-		if ( 'yes' === $this->klarna_debug ) {
-			$this->klarna_log->add( 'klarna', microtime() . ": Adding addresses to order $order_id..." );
-			$this->klarna_log->add( 'klarna', var_export( $klarna_order, true ) );
-		}
 
 		$order_id = $order_id;
 

--- a/includes/checkout/create.php
+++ b/includes/checkout/create.php
@@ -326,6 +326,12 @@ if ( $this->is_rest() ) {
 
 	$klarna_order = new \Klarna\Rest\Checkout\Order( $connector );
 } else {
+	
+	// Allow separate shipping address
+	if( 'yes' == $this->allow_separate_shipping_address ) {
+		$create['options']['allow_separate_shipping_address'] = true;
+	}
+
 	// Klarna_Checkout_Order::$baseUri = $this->klarna_server;
 	// Klarna_Checkout_Order::$contentType = 'application/vnd.klarna.checkout.aggregated-order-v2+json';
 	$klarna_order = new Klarna_Checkout_Order( $connector, $this->klarna_server );

--- a/includes/checkout/resume.php
+++ b/includes/checkout/resume.php
@@ -224,6 +224,11 @@ try {
 			} else {
 				$update['options']['allow_separate_shipping_address'] = false;
 			}
+		} else {
+			// Allow separate shipping address
+			if( 'yes' == $this->allow_separate_shipping_address ) {
+				$create['options']['allow_separate_shipping_address'] = true;
+			}
 		}
 
 		$klarna_order->update( apply_filters( 'kco_update_order', $update ) );

--- a/includes/checkout/thank-you.php
+++ b/includes/checkout/thank-you.php
@@ -139,6 +139,13 @@ if ( WC()->session->get( 'ongoing_klarna_order' ) ) {
 	}
 }
 
+// In some cases the order confirmation callback from Klarna happens after the display of the thankyou page. 
+// In these cases we need to add customer address to the order here. Plugins like WCS needs this when woocommerce_checkout_order_processed hook is run.
+if( '' == get_post_meta( $order_id, '_billing_address_1', true ) ) {
+	include_once( KLARNA_DIR . 'classes/class-klarna-to-wc.php' );
+	WC_Gateway_Klarna_K2WC::add_order_addresses( $order, $klarna_order );
+}
+
 do_action( 'woocommerce_checkout_order_processed', $order_id, $posted_data, $order );
 do_action( 'klarna_before_kco_confirmation', $order_id, $klarna_order );
 

--- a/includes/settings-checkout.php
+++ b/includes/settings-checkout.php
@@ -452,6 +452,13 @@ return apply_filters( 'klarna_checkout_form_fields', array(
 		'default'     => 'B2C',
 		'desc_tip'    => false
 	),
+	'allow_separate_shipping_address'   => array(
+		'title'   => __( 'Separate Shipping Address', 'woocommerce-gateway-klarna' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Allow customer to enter a separate shipping address.', 'woocommerce-gateway-klarna' ),
+		'description' => __( 'Applies to SE, NO, FI, DE & AT. For other countries - use the WooCommerce Shipping options settings.', 'woocommerce-gateway-klarna' ),
+		'default' => 'no'
+	),
 	'create_customer_account'   => array(
 		'title'   => __( 'Create customer account', 'woocommerce-gateway-klarna' ),
 		'type'    => 'checkbox',

--- a/includes/variables-checkout.php
+++ b/includes/variables-checkout.php
@@ -83,6 +83,7 @@ $this->account_login_text  = ( isset( $this->settings['account_login_text'] ) ) 
 
 $this->validate_stock = $this->get_option( 'validate_stock' );
 $this->allowed_customer_types  = ( isset( $this->settings['allowed_customer_types'] ) ) ? $this->settings['allowed_customer_types'] : '';
+$this->allow_separate_shipping_address = ( isset( $this->settings['allow_separate_shipping_address'] ) ) ? $this->settings['allow_separate_shipping_address'] : '';
 
 
 // Helper function to make sure colors start with '#' character

--- a/vendor/klarna/checkout/src/Klarna/Checkout/HTTP/WPTransport.php
+++ b/vendor/klarna/checkout/src/Klarna/Checkout/HTTP/WPTransport.php
@@ -95,7 +95,9 @@ class Klarna_Checkout_HTTP_WPTransport implements Klarna_Checkout_HTTP_Transport
 
 		// For GET requests we need to get Klarna order URI, set in WC session
 		if ( 'GET' == $request->getMethod() && WC()->session->get( 'klarna_request_uri' ) ) {
-			$req_url = WC()->session->get( 'klarna_request_uri' );
+			if ( method_exists( WC()->session, 'get' ) ) {
+				$req_url = WC()->session->get( 'klarna_request_uri' );
+			}
 		} else {
 			$req_url = $request->getURL();
 		}
@@ -105,7 +107,9 @@ class Klarna_Checkout_HTTP_WPTransport implements Klarna_Checkout_HTTP_Transport
 		// Set order URI as session value for GET request
 		if ( 'POST' == $request->getMethod() ) {
 			if ( class_exists( 'WC_Session' ) ) {
-				WC()->session->__unset( 'klarna_request_uri' );
+				if ( method_exists( WC()->session, '__unset' ) ) {
+					WC()->session->__unset( 'klarna_request_uri' );
+				}
 
 				if ( is_wp_error( $my_response ) ) {
 					error_log( var_export( $my_response, true ) );
@@ -115,7 +119,9 @@ class Klarna_Checkout_HTTP_WPTransport implements Klarna_Checkout_HTTP_Transport
 					$klarna_request_uri = $request->getURL();
 				}
 
-				WC()->session->set( 'klarna_request_uri', $klarna_request_uri );
+				if ( method_exists( WC()->session, 'set' ) ) {
+					WC()->session->set( 'klarna_request_uri', $klarna_request_uri );
+				}
 			}
 		}
 

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.3.11
+ * Version:         2.3.12
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.3.11' );
+	define( 'WC_KLARNA_VER', '2.3.12' );
 }
 
 /**


### PR DESCRIPTION
* Update - Adds setting for Allow separate shipping address (KCO V2).
* Fix - Fixes WooCommerce Subscriptions issue - adds customer address to order before woocommerce_checkout_order_processed hook is run.
* Fix - Fixes WooCommerce Subscriptions issue - adds check to activate subscription if parent order already has been set to processing/completed when subscription is created.
* Fix - Fixes invoice fee (no product) issue.