### PR TITLE
2.5.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
-2017.10.23  - version 2.5.0
+2017.10.25  - version 2.5.1
 * Update    - Stops purging all KCO Incomplete orders older than 2 weeks.
 * Fix       - Checks if WC->session exists in checkout-variables.
+* Hotfix    - Fixes issue with KCO Incomplete orders not being registered in time
+* Fix       - Fixes subscriptions manual renewal issue with KCO.
 
 2017.10.23  - version 2.5.0
 * Update    - Updated Klarna PHP-XMLRPC SDK to 5.0.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
 2017.10.23  - version 2.5.0
+* Update    - Stops purging all KCO Incomplete orders older than 2 weeks.
+* Fix       - Checks if WC->session exists in checkout-variables.
+
+2017.10.23  - version 2.5.0
 * Update    - Updated Klarna PHP-XMLRPC SDK to 5.0.
 * Fix		- Send billing address as shipping address to Klarna in process_subscription_payment if shipping isn’t enabled.
 * Fix       - Grabs recurring payment token from payment order if it doesn't exist in subscription (KCO).

--- a/classes/class-klarna-checkout-variables.php
+++ b/classes/class-klarna-checkout-variables.php
@@ -126,7 +126,7 @@ class WC_Gateway_Klarna_Checkout_Variables {
 				break;
 			case 'EUR' :
 				// Check if Ajax country switcher set session value
-				if ( null !== WC()->session() && ! is_admin() && WC()->session->get( 'klarna_euro_country' ) ) {
+				if ( null !== WC()->session && ! is_admin() && WC()->session->get( 'klarna_euro_country' ) ) {
 					$klarna_country = WC()->session->get( 'klarna_euro_country' );
 				} else {
 					if ( '' !== $settings['eid_de'] && '' !== $settings['secret_de'] && ( get_locale() === 'de_DE' || get_locale() === 'de_DE_formal' ) ) {

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -325,6 +325,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			}
 		}
 		wp_reset_postdata();
+
+		/*
 		// Get all KCO Incomplete orders older than 2 weeks.
 		$kco_incomplete_args_1  = array(
 			'post_type'      => 'shop_order',
@@ -345,6 +347,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			}
 		}
 		wp_reset_postdata();
+		*/
 	}
 
 	/**

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -99,14 +99,14 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		add_action( 'klarna_purge_cron_job_hook', array( $this, 'purge_kco_incomplete' ) );
 		// Add activate settings field for recurring orders
 		add_filter( 'klarna_checkout_form_fields', array( $this, 'add_activate_recurring_option' ) );
+
 		// Register new order status
-		add_action( 'init', array( $this, 'register_klarna_incomplete_order_status' ) );
-		add_filter( 'wc_order_statuses', array( $this, 'add_kco_incomplete_to_order_statuses' ) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', array(
 			$this,
 			'kco_incomplete_payment_complete'
 		) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( $this, 'kco_incomplete_payment_complete' ) );
+
 		// Hide "Refunded" and "KCO Incomplete" statuses for KCO orders
 		// add_filter( 'wc_order_statuses', array( $this, 'remove_refunded_and_kco_incomplete' ), 1000 );
 		// Hide "Manual Refund" button for KCO orders
@@ -348,41 +348,6 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		}
 		wp_reset_postdata();
 		*/
-	}
-
-	/**
-	 * Register KCO Incomplete order status
-	 *
-	 * @since  2.0
-	 **/
-	function register_klarna_incomplete_order_status() {
-		if ( 'yes' == $this->debug ) {
-			$show_in_admin_status_list = true;
-		} else {
-			$show_in_admin_status_list = false;
-		}
-		register_post_status( 'wc-kco-incomplete', array(
-			'label'                     => 'KCO incomplete',
-			'public'                    => false,
-			'exclude_from_search'       => false,
-			'show_in_admin_all_list'    => false,
-			'show_in_admin_status_list' => $show_in_admin_status_list,
-			'label_count'               => _n_noop( 'KCO incomplete <span class="count">(%s)</span>', 'KCO incomplete <span class="count">(%s)</span>' ),
-		) );
-	}
-
-	/**
-	 * Add KCO Incomplete to list of order status
-	 *
-	 * @since  2.0
-	 **/
-	function add_kco_incomplete_to_order_statuses( $order_statuses ) {
-		// Add this status only if not in account page (so it doesn't show in My Account list of orders)
-		if ( ! is_account_page() ) {
-			$order_statuses['wc-kco-incomplete'] = 'Incomplete Klarna Checkout';
-		}
-
-		return $order_statuses;
 	}
 
 	/**

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -208,6 +208,9 @@ class WC_Gateway_Klarna_K2WC {
 		if ( WC()->session->get( 'ongoing_klarna_order' ) && wc_get_order( WC()->session->get( 'ongoing_klarna_order' ) ) ) {
 			$orderid = WC()->session->get( 'ongoing_klarna_order' );
 			$order   = wc_get_order( $orderid );
+		} elseif ( WC()->session->get( 'order_awaiting_payment' ) && wc_get_order( WC()->session->get( 'order_awaiting_payment' ) ) ) {
+			$orderid = WC()->session->get( 'order_awaiting_payment' );
+			$order   = wc_get_order( $orderid );
 		} else {
 			// Create order in WooCommerce if we have an email.
 			$order = $this->create_order();

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -298,10 +298,12 @@ if ( wc_notice_count( 'error' ) > 0 ) {
 	} else {
 		// If cart is empty, clear these variables
 		wp_delete_post( WC()->session->get( 'ongoing_klarna_order' ), true ); // Delete WooCommerce order
+
 		WC()->session->__unset( 'klarna_checkout' ); // Klarna order ID
 		WC()->session->__unset( 'klarna_checkout_country' ); // Klarna order ID
 		WC()->session->__unset( 'ongoing_klarna_order' ); // WooCommerce order ID
 		WC()->session->__unset( 'klarna_order_note' ); // Order note
+
 		wp_redirect( wc_get_cart_url() ); // Redirect to cart page
 	} // End if sizeof cart
 }

--- a/includes/variables-checkout.php
+++ b/includes/variables-checkout.php
@@ -81,8 +81,8 @@ $this->send_new_account_email  = ( isset( $this->settings['send_new_account_emai
 $this->account_signup_text = ( isset( $this->settings['account_signup_text'] ) ) ? $this->settings['account_signup_text'] : '';
 $this->account_login_text  = ( isset( $this->settings['account_login_text'] ) ) ? $this->settings['account_login_text'] : '';
 
-$this->validate_stock = $this->get_option( 'validate_stock' );
-$this->allowed_customer_types  = ( isset( $this->settings['allowed_customer_types'] ) ) ? $this->settings['allowed_customer_types'] : '';
+$this->validate_stock                  = $this->get_option( 'validate_stock' );
+$this->allowed_customer_types          = ( isset( $this->settings['allowed_customer_types'] ) ) ? $this->settings['allowed_customer_types'] : '';
 $this->allow_separate_shipping_address = ( isset( $this->settings['allow_separate_shipping_address'] ) ) ? $this->settings['allow_separate_shipping_address'] : '';
 
 
@@ -122,15 +122,16 @@ endif;
 // Set current country based on used currency
 
 // We need to check if WPML is active
-if(!is_admin()) {
-	if( WC()->session->get('client_currency') ) {
-		$customer_selected_currency = WC()->session->get('client_currency');
+if ( ! is_admin() ) {
+	if ( null !== WC()->session && WC()->session->get( 'client_currency' ) ) {
+		$customer_selected_currency = WC()->session->get( 'client_currency' );
 	} else {
 		$customer_selected_currency = get_woocommerce_currency();
 	}
 } else {
 	$customer_selected_currency = get_woocommerce_currency();
 }
+
 switch ( $customer_selected_currency ) {
 	case 'NOK' :
 		$klarna_country = 'NO';
@@ -146,7 +147,7 @@ switch ( $customer_selected_currency ) {
 				$klarna_country = 'FI';
 			} elseif ( get_locale() == 'de_AT' && '' != $this->eid_at && '' != $this->secret_at ) {
 				$klarna_country = 'AT';
-			}  elseif ( get_locale() == 'nl_NL' && '' != $this->eid_nl && '' != $this->secret_nl ) {
+			} elseif ( get_locale() == 'nl_NL' && '' != $this->eid_nl && '' != $this->secret_nl ) {
 				$klarna_country = 'NL';
 			} else {
 				$klarna_country = $this->default_eur_country;

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -169,7 +169,6 @@ function init_klarna_gateway() {
 
 			// Actions.
 			add_action( 'wp_enqueue_scripts', array( $this, 'klarna_load_scripts' ) );
-
 		}
 
 		/**
@@ -253,7 +252,6 @@ function init_klarna_gateway() {
 	add_action( 'woocommerce_order_status_kco-incomplete_to_processing_notification', 'wc_klarna_kco_incomplete_trigger' );
 
 }
-
 add_action( 'plugins_loaded', 'init_klarna_gateway', 2 );
 
 /**
@@ -276,6 +274,42 @@ function add_klarna_gateway( $methods ) {
 	return $methods;
 }
 add_filter( 'woocommerce_payment_gateways', 'add_klarna_gateway' );
+
+add_action( 'init', 'klarna_register_klarna_incomplete_order_status' );
+/**
+ * Register KCO Incomplete order status
+ *
+ * @since  2.0
+ **/
+function klarna_register_klarna_incomplete_order_status() {
+	$checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
+	$show_status = 'yes' !== $checkout_settings['debug'];
+
+	register_post_status( 'wc-kco-incomplete', array(
+		'label'                     => 'KCO incomplete',
+		'public'                    => false,
+		'exclude_from_search'       => false,
+		'show_in_admin_all_list'    => false,
+		'show_in_admin_status_list' => $show_status,
+		'label_count'               => _n_noop( 'KCO incomplete <span class="count">(%s)</span>', 'KCO incomplete <span class="count">(%s)</span>' ),
+	) );
+}
+
+add_filter( 'wc_order_statuses', 'klarna_add_kco_incomplete_to_order_statuses' );
+/**
+ * Add KCO Incomplete to list of order status
+ *
+ * @since  2.0
+ **/
+function klarna_add_kco_incomplete_to_order_statuses( $order_statuses ) {
+	// Add this status only if not in account page (so it doesn't show in My Account list of orders)
+	if ( ! is_account_page() ) {
+		$order_statuses['wc-kco-incomplete'] = 'Incomplete Klarna Checkout';
+	}
+
+	return $order_statuses;
+}
+
 
 /**
  * Helper function that determines if we're at KCO page or not.


### PR DESCRIPTION
2017.10.25  - version 2.5.1
* Update    - Stops purging all KCO Incomplete orders older than 2 weeks.
* Fix       - Checks if WC->session exists in checkout-variables.
* Hotfix    - Fixes issue with KCO Incomplete orders not being registered in time
* Fix       - Fixes subscriptions manual renewal issue with KCO.