### PR TITLE
2.5.5

### DIFF
--- a/assets/js/klarna-checkout.js
+++ b/assets/js/klarna-checkout.js
@@ -291,7 +291,7 @@ jQuery(document).ready(function ($) {
 	});
 
 	// Update cart (v2)
-	$(document).on('change', 'td.product-quantity input[type=number]', function (event) {
+	$(document).on('change', '.product-quantity input[type=number]', function (event) {
 		var minMaxFlag = false;
 
 		// Check max value
@@ -318,7 +318,7 @@ jQuery(document).ready(function ($) {
 				});
 			}
 
-			ancestor = $(this).closest('td.product-quantity');
+			ancestor = $(this).closest('.product-quantity');
 			cart_item_key = $(ancestor).data('cart_item_key');
 			new_quantity = $(this).val();
 			kco_widget = $('#klarna-checkout-widget');

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.12.26  - version 2.5.5
+* Update	- Add shipping email to order if it exist from Klarna.
+* Fix		- Get locale from parent order, if missing in subscription, when sending renewal order data to Klarna.
+* Fix		- Send country code with lowercase letters in subscription renewal order data.
+* Fix		- Improved subscription renewal error logging.
+* Update	- Remove need for td in js logic for quantity change on KCO page.
+* Fix		- WC 3.0 deprecated notices.
+
 2017.11.23  - version 2.5.4
 * Fix       - Fixes email check in KCO ajax updates.
 * Update    - Adds filter (klarna_item_name) to make it possible to filter cart item name before sending it to Klarna.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** WooCommerce Gateway Klarna Changelog ***
 
+2017.11.23  - version 2.5.4
+* Fix       - Fixes email check in KCO ajax updates.
+* Update    - Adds filter (klarna_item_name) to make it possible to filter cart item name before sending it to Klarna.
+* Fix       - Fixes missing shipping issue for repeat customers.
+* Update    - Adds subscription support for Finnish customers for KCO.
+
 2017.10.27  - version 2.5.3
 * Fix       - Temporarily instantiate KCO gateway class on init. Solves subscriptions not being created issue.
 * Update    - Adds Composer support (props @pelmered).

--- a/classes/class-klarna-checkout-ajax.php
+++ b/classes/class-klarna-checkout-ajax.php
@@ -847,7 +847,7 @@ class WC_Gateway_Klarna_Checkout_Ajax {
 			$customer_email = $current_user->user_email;
 		}
 
-		if ( $customer_email ) {
+		if ( ! $customer_email ) {
 			$customer_email = 'guest_checkout@klarna.com';
 		}
 

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -429,6 +429,11 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		if( empty( $klarna_recurring_token ) ) {
 			$klarna_recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_recurring_token', true );	
 		}
+
+		if( empty( $klarna_recurring_token ) ) {
+			$order->add_order_note( __( 'Klarna recurring token could not be retreived.', 'woocommerce-gateway-klarna' ) );
+		}
+
 		$klarna_currency        = get_post_meta( $order_id, '_order_currency', true );
 		$klarna_country         = get_post_meta( $order_id, '_billing_country', true );
 		$klarna_locale          = get_post_meta( $order_id, '_klarna_locale', true );
@@ -559,7 +564,8 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				$this->log->add( 'klarna', 'Klarna API error: ' . var_export( $e, true ) );
 			}
 			$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code %s. Error message %s', 'woocommerce-gateway-klarna' ), $e->getCode(), utf8_encode( $e->getMessage() ) ) );
-
+			add_post_meta( $order_id, 'klarna_subscription_error_info_1', var_export( $klarna_order, true ), true );
+			add_post_meta( $order_id, 'klarna_subscription_error_info_2', var_export( $create, true ), true );
 			return false;
 		}
 	}

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -563,9 +563,16 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			if ( $this->debug == 'yes' ) {
 				$this->log->add( 'klarna', 'Klarna API error: ' . var_export( $e, true ) );
 			}
-			$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code %s. Error message %s', 'woocommerce-gateway-klarna' ), $e->getCode(), utf8_encode( $e->getMessage() ) ) );
+			$pay_load = $e->getPayload();
+			if( 402 == $e->getCode() ) {
+				$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code: %s. Reason: %s. Payment method: %s.', 'woocommerce-gateway-klarna' ), $e->getCode(), $pay_load['reason'], $pay_load['payment_method']['type'] ) );
+			} else {
+				$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code: %s. Reason: %s.', 'woocommerce-gateway-klarna' ), $e->getCode(), $pay_load['http_status_message'] ) );
+			}
+			
 			add_post_meta( $order_id, 'klarna_subscription_error_info_1', var_export( $klarna_order, true ), true );
 			add_post_meta( $order_id, 'klarna_subscription_error_info_2', var_export( $create, true ), true );
+			add_post_meta( $order_id, 'klarna_subscription_error_info_3', var_export( $pay_load, true ), true );
 			return false;
 		}
 	}

--- a/classes/class-klarna-checkout.php
+++ b/classes/class-klarna-checkout.php
@@ -423,30 +423,42 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		}
 
 		$order_id = klarna_wc_get_order_id( $order );
-
+		
+		// Reccuring token
 		$klarna_recurring_token = get_post_meta( $order_id, '_klarna_recurring_token', true );
 		// If the recurring token isn't stored in the subscription, grab it from parent order.
 		if( empty( $klarna_recurring_token ) ) {
 			$klarna_recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_recurring_token', true );	
 		}
-
 		if( empty( $klarna_recurring_token ) ) {
-			$order->add_order_note( __( 'Klarna recurring token could not be retreived.', 'woocommerce-gateway-klarna' ) );
+			$order->add_order_note( __( 'Klarna recurring token could not be retrieved.', 'woocommerce-gateway-klarna' ) );
 		}
-
+		
+		// Locale
+		$klarna_locale          = get_post_meta( $order_id, '_klarna_locale', true );
+		// If the locale isn't stored in the subscription, grab it from parent order.
+		if( empty( $klarna_locale ) ) {
+			$klarna_locale = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_locale', true );	
+		}
+		if( empty( $klarna_locale ) ) {
+			$klarna_locale = 'en-gb';
+			$order->add_order_note( __( 'Klarna locale could not be retrieved, using English as fallback language.', 'woocommerce-gateway-klarna' ) );
+		}
+		
 		$klarna_currency        = get_post_meta( $order_id, '_order_currency', true );
 		$klarna_country         = get_post_meta( $order_id, '_billing_country', true );
-		$klarna_locale          = get_post_meta( $order_id, '_klarna_locale', true );
+		
 		// Can't use same methods to retrieve Eid and secret that are used in frontend.
 		// Need to use order billing country as base instead.
 		$klarna_checkout_settings = get_option( 'woocommerce_klarna_checkout_settings' );
 		$klarna_country_lowercase = strtolower( $klarna_country );
 		$klarna_eid               = $klarna_checkout_settings[ 'eid_' . $klarna_country_lowercase ];
 		$klarna_secret            = $klarna_checkout_settings[ 'secret_' . $klarna_country_lowercase ];
+		$billing_country 		  = get_post_meta( $order_id, '_billing_country', true );
 		$klarna_billing           = array(
 			'postal_code'    => get_post_meta( $order_id, '_billing_postcode', true ),
 			'email'          => get_post_meta( $order_id, '_billing_email', true ),
-			'country'        => get_post_meta( $order_id, '_billing_country', true ),
+			'country'        => strtolower( $billing_country ),
 			'city'           => get_post_meta( $order_id, '_billing_city', true ),
 			'family_name'    => get_post_meta( $order_id, '_billing_last_name', true ),
 			'given_name'     => get_post_meta( $order_id, '_billing_first_name', true ),
@@ -456,10 +468,11 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 		if( wc_shipping_enabled() ) {
 			$shipping_email           = get_post_meta( $order_id, '_shipping_email', true ) ? get_post_meta( $order_id, '_shipping_email', true ) : get_post_meta( $order_id, '_billing_email', true );
 			$shipping_phone           = get_post_meta( $order_id, '_shipping_phone', true ) ? get_post_meta( $order_id, '_shipping_phone', true ) : get_post_meta( $order_id, '_billing_phone', true );
+			$shipping_country		  = get_post_meta( $order_id, '_shipping_country', true );
 			$klarna_shipping          = array(
 				'postal_code'    => get_post_meta( $order_id, '_shipping_postcode', true ),
 				'email'          => $shipping_email,
-				'country'        => get_post_meta( $order_id, '_shipping_country', true ),
+				'country'        => strtolower( $shipping_country ),
 				'city'           => get_post_meta( $order_id, '_shipping_city', true ),
 				'family_name'    => get_post_meta( $order_id, '_shipping_last_name', true ),
 				'given_name'     => get_post_meta( $order_id, '_shipping_first_name', true ),
@@ -470,7 +483,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			$klarna_shipping		= array(
 				'postal_code'    => get_post_meta( $order_id, '_billing_postcode', true ),
 				'email'          => get_post_meta( $order_id, '_billing_email', true ),
-				'country'        => get_post_meta( $order_id, '_billing_country', true ),
+				'country'        => strtolower( $billing_country ),
 				'city'           => get_post_meta( $order_id, '_billing_city', true ),
 				'family_name'    => get_post_meta( $order_id, '_billing_last_name', true ),
 				'given_name'     => get_post_meta( $order_id, '_billing_first_name', true ),
@@ -561,7 +574,7 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 			return true;
 		} catch ( Klarna_Checkout_ApiErrorException $e ) {
 			if ( $this->debug == 'yes' ) {
-				$this->log->add( 'klarna', 'Klarna API error: ' . var_export( $e, true ) );
+				$this->log->add( 'klarna', 'Klarna subscription payment API error: ' . var_export( $e, true ) );
 			}
 			$pay_load = $e->getPayload();
 			if( 402 == $e->getCode() ) {
@@ -570,9 +583,9 @@ class WC_Gateway_Klarna_Checkout extends WC_Gateway_Klarna {
 				$order->add_order_note( sprintf( __( 'Klarna subscription payment failed. Error code: %s. Reason: %s.', 'woocommerce-gateway-klarna' ), $e->getCode(), $pay_load['http_status_message'] ) );
 			}
 			
-			add_post_meta( $order_id, 'klarna_subscription_error_info_1', var_export( $klarna_order, true ), true );
-			add_post_meta( $order_id, 'klarna_subscription_error_info_2', var_export( $create, true ), true );
-			add_post_meta( $order_id, 'klarna_subscription_error_info_3', var_export( $pay_load, true ), true );
+			update_post_meta( $order_id, 'klarna_subscription_error_info_1', var_export( $klarna_order, true ) );
+			update_post_meta( $order_id, 'klarna_subscription_error_info_2', var_export( $create, true ) );
+			update_post_meta( $order_id, 'klarna_subscription_error_info_3', var_export( $pay_load, true ) );
 			return false;
 		}
 	}

--- a/classes/class-klarna-to-wc.php
+++ b/classes/class-klarna-to-wc.php
@@ -696,6 +696,7 @@ class WC_Gateway_Klarna_K2WC {
 			'postcode'   => $klarna_order['shipping_address']['postal_code'],
 			'city'       => $klarna_order['shipping_address']['city'],
 			'country'    => strtoupper( $klarna_order['shipping_address']['country'] ),
+			'email'      => $klarna_order['shipping_address']['email'],
 			'phone'      => $klarna_order['shipping_address']['phone'],
 		);
 

--- a/includes/checkout/checkout.php
+++ b/includes/checkout/checkout.php
@@ -38,7 +38,7 @@ if ( ! $kco_show_kco ) {
 
 // Check if there are any recurring items in the cart and if it's a "recurring" country
 if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
-	if ( ! in_array( strtoupper( $kco_klarna_country ), array( 'SE', 'NO' ), true ) ) {
+	if ( ! in_array( strtoupper( $kco_klarna_country ), array( 'SE', 'NO', 'FI' ), true ) ) {
 		$checkout_url = wc_get_checkout_url();
 		wp_safe_redirect( $checkout_url );
 		exit;

--- a/includes/checkout/create.php
+++ b/includes/checkout/create.php
@@ -241,7 +241,7 @@ if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_cont
 	}
 
 	if ( $subscription_product_id ) {
-		$subscription_expiration_time = WC_Subscriptions_Product::get_expiration_date( $fetched_subscription_product_id );
+		$subscription_expiration_time = WC_Subscriptions_Product::get_expiration_date( $subscription_product_id );
 		if ( 0 !== $subscription_expiration_time ) {
 			$end_time = date( 'Y-m-d\TH:i', strtotime( $subscription_expiration_time ) );
 		} else {
@@ -249,7 +249,7 @@ if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_cont
 		}
 
 		$klarna_subscription_info = array(
-			'subscription_name'            => 'Subscription: ' . get_the_title( $fetched_subscription_product_id ),
+			'subscription_name'            => 'Subscription: ' . get_the_title( $subscription_product_id ),
 			'start_time'                   => date( 'Y-m-d\TH:i' ),
 			'end_time'                     => $end_time,
 			'auto_renewal_of_subscription' => true

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.5.4
+ * Version:         2.5.5
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.5.4' );
+	define( 'WC_KLARNA_VER', '2.5.5' );
 }
 
 /**

--- a/woocommerce-gateway-klarna.php
+++ b/woocommerce-gateway-klarna.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Klarna Gateway
  * Plugin URI:      https://woocommerce.com/products/klarna/
  * Description:     Extends WooCommerce. Provides a <a href="http://www.klarna.se" target="_blank">Klarna</a> gateway for WooCommerce.
- * Version:         2.5.3
+ * Version:         2.5.4
  * Author:          WooCommerce
  * Author URI:      https://woocommerce.com/
  * Developer:       Krokedil
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WC_KLARNA_VER' ) ) {
-	define( 'WC_KLARNA_VER', '2.5.3' );
+	define( 'WC_KLARNA_VER', '2.5.4' );
 }
 
 /**


### PR DESCRIPTION
* Update - Add shipping email to order if it exist from Klarna.
* Fix	 - Get locale from parent order, if missing in subscription, when sending renewal order data to Klarna.
* Fix	 - Send country code with lowercase letters in subscription renewal order data.
* Fix - Improved subscription renewal error logging.
* Update - Remove need for td in js logic for quantity change on KCO page.
* Fix - WC 3.0 deprecated notices.